### PR TITLE
74 add fractional and discrete intersection methods to intersect trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bedrs"
-version = "0.0.35"
+version = "0.0.36"
 edition = "2021"
 license = "MIT"
 description = "Genomic interval library in rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["interval", "bioinformatics", "ranges", "genomic", "bed"]
 
 [dependencies]
 anyhow = "1.0.65"
+num-traits = "0.2.16"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 serde = { version = "1.0.181", features = ["derive"], optional = true }
@@ -28,3 +29,6 @@ bincode = "1.3.3"
 [[bench]]
 name = "benchmark"
 harness = false
+
+[profile.bench]
+debug = true

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -12,10 +12,10 @@ use overlap::{overlap_base, overlap_cross, overlap_genomic, overlap_meta};
 criterion_group!(
     find,
     find_base,
-    find_iter_base,
-    find_iter_sort_base,
     find_genomic,
+    find_iter_base,
     find_iter_genomic,
+    find_iter_sort_base,
     find_iter_sort_genomic
 );
 criterion_group!(

--- a/benches/find.rs
+++ b/benches/find.rs
@@ -4,9 +4,12 @@ use bedrs::{
 };
 use criterion::Criterion;
 
+const N: usize = 10000;
+const SIZE: usize = 100;
+
 pub fn find_base(c: &mut Criterion) {
-    let records = (0..100)
-        .map(|x| (x, x + 50))
+    let records = (0..N)
+        .map(|x| (x, x + SIZE))
         .map(|(x, y)| Interval::new(x, y))
         .collect();
     let query = Interval::new(20, 30);
@@ -15,8 +18,8 @@ pub fn find_base(c: &mut Criterion) {
 }
 
 pub fn find_iter_base(c: &mut Criterion) {
-    let records = (0..100)
-        .map(|x| (x, x + 50))
+    let records = (0..N)
+        .map(|x| (x, x + SIZE))
         .map(|(x, y)| Interval::new(x, y))
         .collect();
     let query = Interval::new(20, 30);
@@ -27,8 +30,8 @@ pub fn find_iter_base(c: &mut Criterion) {
 }
 
 pub fn find_iter_sort_base(c: &mut Criterion) {
-    let records = (0..100)
-        .map(|x| (x, x + 50))
+    let records = (0..N)
+        .map(|x| (x, x + SIZE))
         .map(|(x, y)| Interval::new(x, y))
         .collect();
     let query = Interval::new(20, 30);
@@ -40,8 +43,8 @@ pub fn find_iter_sort_base(c: &mut Criterion) {
 }
 
 pub fn find_genomic(c: &mut Criterion) {
-    let records = (0..100)
-        .map(|x| (x, x + 50, x % 5))
+    let records = (0..N)
+        .map(|x| (x, x + SIZE, x % 5))
         .map(|(x, y, z)| GenomicInterval::new(z, x, y))
         .collect();
     let query = GenomicInterval::new(2, 20, 30);
@@ -50,8 +53,8 @@ pub fn find_genomic(c: &mut Criterion) {
 }
 
 pub fn find_iter_genomic(c: &mut Criterion) {
-    let records = (0..100)
-        .map(|x| (x, x + 50, x % 5))
+    let records = (0..N)
+        .map(|x| (x, x + SIZE, x % 5))
         .map(|(x, y, z)| GenomicInterval::new(z, x, y))
         .collect();
     let query = GenomicInterval::new(2, 20, 30);
@@ -62,8 +65,8 @@ pub fn find_iter_genomic(c: &mut Criterion) {
 }
 
 pub fn find_iter_sort_genomic(c: &mut Criterion) {
-    let records = (0..100)
-        .map(|x| (x, x + 50, x % 5))
+    let records = (0..N)
+        .map(|x| (x, x + SIZE, x % 5))
         .map(|(x, y, z)| GenomicInterval::new(z, x, y))
         .collect();
     let query = GenomicInterval::new(2, 20, 30);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,40 @@
 //! 1. [Coordinates] :: which applies to individual interval records.
 //! 2. [Container] :: which applies to sets of interval records.
 //!
+//! ### Coordinates
+//!
+//! The [Coordinates] trait is the base trait for all interval types.
+//! It is the trait that defines the `<chr, start, stop>` coordinates.
+//! It is also the trait that defines the methods for interval arithmetic.
+//! This trait is generic over the type of the coordinates.
+//!
+//! You can explore the full functionality of this trait by looking at the
+//! [crate::traits::interval] module.
+//!
+//! Some examples of the functionality are:
+//! - [Intersect](crate::traits::interval::Intersect)
+//! - [Overlap](crate::traits::interval::Overlap)
+//! - [Subtract](crate::traits::interval::Subtract)
+//!
+//! ### Container
+//!
+//! The [Container] trait is the base trait for all interval containers.
+//! It is the trait that defines the methods for set operations.
+//! This trait is generic over the type of the coordinates.
+//! It is also generic over the type of the interval.
+//! This means that you can have a container of any interval type.
+//!
+//! You can explore the full functionality of this trait by looking at the
+//! [crate::traits::container] module.
+//!
+//! Some examples of the functionality are:
+//! - [Merge](crate::traits::container::Merge)
+//! - [SetSubtract](crate::traits::container::SetSubtract)
+//! - [Internal](crate::traits::container::Internal)
+//! - [Sample](crate::traits::container::Sample)
+//! - [Find](crate::traits::container::Find)
+//! - [Bound](crate::traits::container::Bound)
+//!
 //! ## Types
 //!
 //! This library has batteries included and has a few types you can use immediately or

--- a/src/traits/container/container.rs
+++ b/src/traits/container/container.rs
@@ -28,6 +28,9 @@ where
     /// Returns a mutable reference to the internal sorted flag
     fn sorted_mut(&mut self) -> &mut bool;
 
+    /// Returns the maximum length of the intervals in the container
+    fn max_len(&self) -> Option<T>;
+
     /// Sets the internal state to sorted
     ///
     /// >> This would likely not be used directly by the user.
@@ -180,12 +183,15 @@ mod testing {
 
     struct CustomContainer {
         records: Vec<Interval<usize>>,
+        max_len: Option<usize>,
         is_sorted: bool,
     }
     impl Container<usize, Interval<usize>> for CustomContainer {
         fn new(records: Vec<Interval<usize>>) -> Self {
+            let max_len = records.iter().map(|iv| iv.len()).max();
             Self {
                 records,
+                max_len,
                 is_sorted: false,
             }
         }
@@ -201,6 +207,9 @@ mod testing {
         fn sorted_mut(&mut self) -> &mut bool {
             &mut self.is_sorted
         }
+        fn max_len(&self) -> Option<usize> {
+            self.max_len
+        }
     }
 
     #[test]
@@ -208,6 +217,7 @@ mod testing {
         let records = vec![Interval::new(10, 100); 4];
         let container = CustomContainer {
             records,
+            max_len: Some(90),
             is_sorted: false,
         };
         assert_eq!(container.len(), 4);
@@ -224,6 +234,7 @@ mod testing {
         ];
         let mut container = CustomContainer {
             records,
+            max_len: Some(10),
             is_sorted: false,
         };
         container.sort();
@@ -237,6 +248,7 @@ mod testing {
         let records = Vec::new();
         let container = CustomContainer {
             records,
+            max_len: None,
             is_sorted: false,
         };
         assert!(container.is_empty());

--- a/src/traits/container/find.rs
+++ b/src/traits/container/find.rs
@@ -243,6 +243,17 @@ mod testing {
     }
 
     #[test]
+    fn test_find_iter_exact() {
+        let query = Interval::new(17, 27);
+        let starts = vec![10, 15, 20, 25];
+        let ends = vec![40, 45, 50, 55];
+        let set = IntervalSet::from_endpoints_unchecked(&starts, &ends);
+        let overlaps = set.find_iter_exact(&query, 7);
+        let num_overlaps = overlaps.count();
+        assert_eq!(num_overlaps, 1);
+    }
+
+    #[test]
     fn test_find_iter_sorted_min() {
         let query = Interval::new(17, 27);
         let starts = vec![10, 15, 20, 25];
@@ -252,5 +263,17 @@ mod testing {
         let overlaps = set.find_iter_sorted_min(&query, 5).unwrap();
         let num_overlaps = overlaps.count();
         assert_eq!(num_overlaps, 3);
+    }
+
+    #[test]
+    fn test_find_iter_sorted_exact() {
+        let query = Interval::new(17, 27);
+        let starts = vec![10, 15, 20, 25];
+        let ends = vec![40, 45, 50, 55];
+        let mut set = IntervalSet::from_endpoints_unchecked(&starts, &ends);
+        set.sort();
+        let overlaps = set.find_iter_sorted_exact(&query, 7).unwrap();
+        let num_overlaps = overlaps.count();
+        assert_eq!(num_overlaps, 1);
     }
 }

--- a/src/traits/container/find.rs
+++ b/src/traits/container/find.rs
@@ -17,11 +17,10 @@ where
     /// the same `Container` type with all found regions.
     fn find(&self, query: &I) -> Self::ContainerType {
         let records = self
-            .records()
-            .iter()
-            .filter(|x| x.overlaps(query))
+            .find_iter(query)
+            .into_iter()
             .map(|x| x.to_owned())
-            .collect();
+            .collect::<Vec<I>>();
         Self::ContainerType::new(records)
     }
 
@@ -29,11 +28,10 @@ where
     /// amount and returns the same `Container` type with all found regions.
     fn find_min(&self, query: &I, minimum: T) -> Self::ContainerType {
         let records = self
-            .records()
-            .iter()
-            .filter(|x| x.overlaps_by(query, minimum))
+            .find_iter_min(query, minimum)
+            .into_iter()
             .map(|x| x.to_owned())
-            .collect();
+            .collect::<Vec<I>>();
         Self::ContainerType::new(records)
     }
 
@@ -41,12 +39,42 @@ where
     /// amount and returns the same `Container` type with all found regions.
     fn find_exact(&self, query: &I, exact: T) -> Self::ContainerType {
         let records = self
-            .records()
-            .iter()
-            .filter(|x| x.overlaps_by_exactly(query, exact))
+            .find_iter_exact(query, exact)
+            .into_iter()
             .map(|x| x.to_owned())
-            .collect();
+            .collect::<Vec<I>>();
         Self::ContainerType::new(records)
+    }
+
+    /// Finds all intervals that overlap a query by some fraction
+    /// of the query length and returns the same `Container` type with all found regions.
+    fn find_query_frac(&self, query: &I, frac: f64) -> Result<Self::ContainerType, SetError> {
+        let records = match self.find_iter_query_frac(query, frac) {
+            Ok(iter) => iter.into_iter().map(|x| x.to_owned()).collect::<Vec<I>>(),
+            Err(e) => return Err(e),
+        };
+        Ok(Self::ContainerType::new(records))
+    }
+
+    /// Finds all intervals that overlap a query by some fraction
+    /// of the target length and returns the same `Container` type with all found regions.
+    fn find_target_frac(&self, query: &I, frac: f64) -> Result<Self::ContainerType, SetError> {
+        let records = match self.find_iter_target_frac(query, frac) {
+            Ok(iter) => iter.into_iter().map(|x| x.to_owned()).collect::<Vec<I>>(),
+            Err(e) => return Err(e),
+        };
+        Ok(Self::ContainerType::new(records))
+    }
+
+    /// Finds all intervals that overlap a query by some fraction
+    /// of **both** the query and target lengths and returns the
+    /// same `Container` type with all found regions.
+    fn find_reciprocal_frac(&self, query: &I, frac: f64) -> Result<Self::ContainerType, SetError> {
+        let records = match self.find_iter_reciprocal_frac(query, frac) {
+            Ok(iter) => iter.into_iter().map(|x| x.to_owned()).collect::<Vec<I>>(),
+            Err(e) => return Err(e),
+        };
+        Ok(Self::ContainerType::new(records))
     }
 
     /// Creates an iterator that finds all overlapping regions
@@ -70,6 +98,63 @@ where
     /// Does not assume a sorted Container
     fn find_iter_exact<'a>(&'a self, query: &'a I, exact: T) -> FindIter<'_, T, I> {
         FindIter::new(self.records(), query, QueryMethod::CompareExact(exact))
+    }
+
+    /// Creates an iterator that finds all overlapping regions
+    /// by some fraction of the query length
+    ///
+    /// Does not assume a sorted Container
+    fn find_iter_query_frac<'a>(
+        &'a self,
+        query: &'a I,
+        frac: f64,
+    ) -> Result<FindIter<'_, T, I>, SetError> {
+        if frac <= 0.0 || frac > 1.0 {
+            return Err(SetError::FractionUnbounded { frac });
+        }
+        Ok(FindIter::new(
+            self.records(),
+            query,
+            QueryMethod::CompareByQueryFraction(frac),
+        ))
+    }
+
+    /// Creates an iterator that finds all overlapping regions
+    /// by some fraction of the target length
+    ///
+    /// Does not assume a sorted Container
+    fn find_iter_target_frac<'a>(
+        &'a self,
+        query: &'a I,
+        frac: f64,
+    ) -> Result<FindIter<'_, T, I>, SetError> {
+        if frac <= 0.0 || frac > 1.0 {
+            return Err(SetError::FractionUnbounded { frac });
+        }
+        Ok(FindIter::new(
+            self.records(),
+            query,
+            QueryMethod::CompareByTargetFraction(frac),
+        ))
+    }
+
+    /// Creates an iterator that finds all overlapping regions
+    /// by some fraction of **both** the query and target length
+    ///
+    /// Does not assume a sorted Container
+    fn find_iter_reciprocal_frac<'a>(
+        &'a self,
+        query: &'a I,
+        frac: f64,
+    ) -> Result<FindIter<'_, T, I>, SetError> {
+        if frac <= 0.0 || frac > 1.0 {
+            return Err(SetError::FractionUnbounded { frac });
+        }
+        Ok(FindIter::new(
+            self.records(),
+            query,
+            QueryMethod::CompareReciprocalFraction(frac),
+        ))
     }
 
     /// Creates a Result Iterator that finds all overlapping regions
@@ -110,6 +195,54 @@ where
     ) -> Result<FindIterSorted<'_, T, I>, SetError> {
         if self.is_sorted() {
             Ok(self.find_iter_sorted_exact_unchecked(query, exact))
+        } else {
+            Err(SetError::UnsortedSet)
+        }
+    }
+
+    /// Creates a Result Iterator that finds all overlapping regions
+    /// by some fraction of the query length
+    ///
+    /// First checks to see if container is sorted
+    fn find_iter_sorted_query_frac<'a>(
+        &'a self,
+        query: &'a I,
+        frac: f64,
+    ) -> Result<FindIterSorted<'_, T, I>, SetError> {
+        if self.is_sorted() {
+            Ok(self.find_iter_sorted_query_frac_unchecked(query, frac)?)
+        } else {
+            Err(SetError::UnsortedSet)
+        }
+    }
+
+    /// Creates a Result Iterator that finds all overlapping regions
+    /// by some fraction of the target length
+    ///
+    /// First checks to see if container is sorted
+    fn find_iter_sorted_target_frac<'a>(
+        &'a self,
+        query: &'a I,
+        frac: f64,
+    ) -> Result<FindIterSorted<'_, T, I>, SetError> {
+        if self.is_sorted() {
+            Ok(self.find_iter_sorted_target_frac_unchecked(query, frac)?)
+        } else {
+            Err(SetError::UnsortedSet)
+        }
+    }
+
+    /// Creates a Result Iterator that finds all overlapping regions
+    /// by some fraction of **both** the query and target length
+    ///
+    /// First checks to see if container is sorted
+    fn find_iter_sorted_reciprocal_frac<'a>(
+        &'a self,
+        query: &'a I,
+        frac: f64,
+    ) -> Result<FindIterSorted<'_, T, I>, SetError> {
+        if self.is_sorted() {
+            Ok(self.find_iter_sorted_reciprocal_frac_unchecked(query, frac)?)
         } else {
             Err(SetError::UnsortedSet)
         }
@@ -160,12 +293,74 @@ where
             QueryMethod::CompareExact(exact),
         )
     }
+
+    /// Creates an Iterator that finds all overlapping regions
+    /// by some fraction of the query length
+    ///
+    /// Assumes a sorted Container.
+    fn find_iter_sorted_query_frac_unchecked<'a>(
+        &'a self,
+        query: &'a I,
+        frac: f64,
+    ) -> Result<FindIterSorted<'_, T, I>, SetError> {
+        if frac <= 0.0 || frac > 1.0 {
+            return Err(SetError::FractionUnbounded { frac });
+        }
+        Ok(FindIterSorted::new(
+            self.records(),
+            query,
+            self.lower_bound_unchecked(query),
+            QueryMethod::CompareByQueryFraction(frac),
+        ))
+    }
+
+    /// Creates an Iterator that finds all overlapping regions
+    /// by some fraction of the target length
+    ///
+    /// Assumes a sorted Container.
+    fn find_iter_sorted_target_frac_unchecked<'a>(
+        &'a self,
+        query: &'a I,
+        frac: f64,
+    ) -> Result<FindIterSorted<'_, T, I>, SetError> {
+        if frac <= 0.0 || frac > 1.0 {
+            return Err(SetError::FractionUnbounded { frac });
+        }
+        Ok(FindIterSorted::new(
+            self.records(),
+            query,
+            self.lower_bound_unchecked(query),
+            QueryMethod::CompareByTargetFraction(frac),
+        ))
+    }
+
+    /// Creates an Iterator that finds all overlapping regions
+    /// by some fraction of **both** the query and target length
+    ///
+    /// Assumes a sorted Container.
+    fn find_iter_sorted_reciprocal_frac_unchecked<'a>(
+        &'a self,
+        query: &'a I,
+        frac: f64,
+    ) -> Result<FindIterSorted<'_, T, I>, SetError> {
+        if frac <= 0.0 || frac > 1.0 {
+            return Err(SetError::FractionUnbounded { frac });
+        }
+        Ok(FindIterSorted::new(
+            self.records(),
+            query,
+            self.lower_bound_unchecked(query),
+            QueryMethod::CompareReciprocalFraction(frac),
+        ))
+    }
 }
 
 #[cfg(test)]
 mod testing {
     use super::Find;
-    use crate::{traits::Container, GenomicInterval, GenomicIntervalSet, Interval, IntervalSet};
+    use crate::{
+        traits::Container, Coordinates, GenomicInterval, GenomicIntervalSet, Interval, IntervalSet,
+    };
 
     #[test]
     fn find() {
@@ -322,5 +517,268 @@ mod testing {
         let last = overlaps.last();
         assert_eq!(first, GenomicInterval::new(3, 20, 30));
         assert!(last.is_none());
+    }
+
+    #[test]
+    fn find_query_frac_a() {
+        let query = Interval::new(10, 20);
+        let frac = 0.5;
+        let intervals = vec![
+            Interval::new(0, 10),
+            Interval::new(5, 15), // first
+            Interval::new(7, 17),
+            Interval::new(10, 20),
+            Interval::new(15, 25),
+            Interval::new(17, 27), // bounded, but missing overlap req
+            Interval::new(20, 30),
+        ];
+        let expected = vec![
+            Interval::new(5, 15),
+            Interval::new(7, 17),
+            Interval::new(10, 20),
+            Interval::new(15, 25),
+        ];
+        let set = IntervalSet::from_sorted(intervals).unwrap();
+        let overlaps = set.find_query_frac(&query, frac).unwrap();
+        for (i, j) in overlaps.records().iter().zip(expected.iter()) {
+            assert!(i.eq(j))
+        }
+    }
+
+    #[test]
+    fn find_query_frac_b() {
+        let query = Interval::new(10, 20);
+        let frac = 0.2;
+        let intervals = vec![
+            Interval::new(0, 10),
+            Interval::new(5, 15), // first
+            Interval::new(7, 17),
+            Interval::new(10, 20),
+            Interval::new(15, 25),
+            Interval::new(17, 27), // last
+            Interval::new(20, 30),
+        ];
+        let expected = vec![
+            Interval::new(5, 15),
+            Interval::new(7, 17),
+            Interval::new(10, 20),
+            Interval::new(15, 25),
+            Interval::new(17, 27),
+        ];
+        let set = IntervalSet::from_sorted(intervals).unwrap();
+        let overlaps = set.find_query_frac(&query, frac).unwrap();
+        for (i, j) in overlaps.records().iter().zip(expected.iter()) {
+            assert!(i.eq(j))
+        }
+    }
+
+    #[test]
+    fn find_query_frac_c() {
+        let query = Interval::new(10, 20);
+        let frac = 1.0;
+        let intervals = vec![
+            Interval::new(0, 10),
+            Interval::new(5, 15),
+            Interval::new(7, 17),
+            Interval::new(10, 20), // only
+            Interval::new(15, 25),
+            Interval::new(17, 27),
+            Interval::new(20, 30),
+        ];
+        let expected = vec![Interval::new(10, 20)];
+        let set = IntervalSet::from_sorted(intervals).unwrap();
+        let overlaps = set.find_query_frac(&query, frac).unwrap();
+        for (i, j) in overlaps.records().iter().zip(expected.iter()) {
+            assert!(i.eq(j))
+        }
+    }
+
+    #[test]
+    fn find_iter_sorted_query_frac() {
+        let query = Interval::new(10, 20);
+        let frac = 0.5;
+        let intervals = vec![
+            Interval::new(0, 10),
+            Interval::new(5, 15), // first
+            Interval::new(7, 17),
+            Interval::new(10, 20),
+            Interval::new(15, 25),
+            Interval::new(17, 27), // bounded, but missing overlap req
+            Interval::new(20, 30),
+        ];
+        let expected = vec![
+            Interval::new(5, 15),
+            Interval::new(7, 17),
+            Interval::new(10, 20),
+            Interval::new(15, 25),
+        ];
+        let set = IntervalSet::from_sorted(intervals).unwrap();
+        let overlaps = set.find_iter_sorted_query_frac(&query, frac).unwrap();
+        for (i, j) in overlaps.into_iter().zip(expected.iter()) {
+            assert!(i.eq(j))
+        }
+    }
+
+    #[test]
+    fn find_target_frac_a() {
+        let query = Interval::new(10, 20);
+        let frac = 0.5;
+        let intervals = vec![
+            Interval::new(2, 12), // bounded, but missing overlap req
+            Interval::new(5, 15), // first
+            Interval::new(7, 17),
+            Interval::new(7, 37),  // bounded, but missing overlap req
+            Interval::new(10, 20), // last
+            Interval::new(12, 22), // bounded, but missing overlap req
+        ];
+        let expected = vec![
+            Interval::new(5, 15),
+            Interval::new(7, 17),
+            Interval::new(10, 20),
+        ];
+        let set = IntervalSet::from_sorted(intervals).unwrap();
+        let overlaps = set.find_target_frac(&query, frac).unwrap();
+        for (i, j) in overlaps.records().iter().zip(expected.iter()) {
+            assert!(i.eq(j))
+        }
+    }
+
+    #[test]
+    fn find_target_frac_b() {
+        let query = Interval::new(10, 20);
+        let frac = 1.0;
+        let intervals = vec![
+            Interval::new(2, 12),  // bounded, but missing overlap req
+            Interval::new(5, 15),  // bounded, but missing overlap req
+            Interval::new(7, 17),  // bounded, but missing overlap req
+            Interval::new(7, 37),  // bounded, but missing overlap req
+            Interval::new(10, 20), // only
+            Interval::new(12, 22), // bounded, but missing overlap req
+        ];
+        let expected = vec![Interval::new(10, 20)];
+        let set = IntervalSet::from_sorted(intervals).unwrap();
+        let overlaps = set.find_target_frac(&query, frac).unwrap();
+        for (i, j) in overlaps.records().iter().zip(expected.iter()) {
+            assert!(i.eq(j))
+        }
+    }
+
+    #[test]
+    fn find_target_frac_c() {
+        let query = Interval::new(10, 20);
+        let frac = 0.9;
+        let intervals = vec![
+            Interval::new(8, 18), // bounded, but missing overlap req
+            Interval::new(9, 19), // first
+            Interval::new(10, 20),
+            Interval::new(11, 21), // last
+            Interval::new(12, 22), // bounded, but missing overlap req
+        ];
+        let expected = vec![
+            Interval::new(9, 19),
+            Interval::new(10, 20),
+            Interval::new(11, 21),
+        ];
+        let set = IntervalSet::from_sorted(intervals).unwrap();
+        let overlaps = set.find_target_frac(&query, frac).unwrap();
+        for (i, j) in overlaps.records().iter().zip(expected.iter()) {
+            assert!(i.eq(j))
+        }
+    }
+
+    #[test]
+    fn find_iter_sorted_target_frac() {
+        let query = Interval::new(10, 20);
+        let frac = 0.5;
+        let intervals = vec![
+            Interval::new(2, 12), // bounded, but missing overlap req
+            Interval::new(5, 15), // first
+            Interval::new(7, 17),
+            Interval::new(7, 37),  // bounded, but missing overlap req
+            Interval::new(10, 20), // last
+            Interval::new(12, 22), // bounded, but missing overlap req
+        ];
+        let expected = vec![
+            Interval::new(5, 15),
+            Interval::new(7, 17),
+            Interval::new(10, 20),
+        ];
+        let set = IntervalSet::from_sorted(intervals).unwrap();
+        let overlaps = set.find_iter_sorted_target_frac(&query, frac).unwrap();
+        for (i, j) in overlaps.into_iter().zip(expected.iter()) {
+            assert!(i.eq(j))
+        }
+    }
+
+    #[test]
+    fn find_reciprocal_frac_a() {
+        let query = Interval::new(10, 20);
+        let frac = 0.9;
+        let intervals = vec![
+            // overlaps by 80% of target
+            Interval::new(8, 18),
+            // overlaps by 90% of target and query
+            Interval::new(9, 19), // only
+            // overlaps by 90% of query but not target
+            Interval::new(9, 20),
+            // overlaps by >90% of target but not query
+            Interval::new(15, 18),
+            // outside interval
+            Interval::new(20, 30),
+        ];
+        let expected = vec![Interval::new(9, 19)];
+        let set = IntervalSet::from_sorted(intervals).unwrap();
+        let overlaps = set.find_reciprocal_frac(&query, frac).unwrap();
+        for (i, j) in overlaps.records().iter().zip(expected.iter()) {
+            assert!(i.eq(j))
+        }
+    }
+
+    #[test]
+    fn find_iter_sorted_reciprocal_frac_a() {
+        let query = Interval::new(10, 20);
+        let frac = 0.9;
+        let intervals = vec![
+            // overlaps by 80% of target
+            Interval::new(8, 18),
+            // overlaps by 90% of target and query
+            Interval::new(9, 19), // only
+            // overlaps by 90% of query but not target
+            Interval::new(9, 20),
+            // overlaps by >90% of target but not query
+            Interval::new(15, 18),
+            // outside interval
+            Interval::new(20, 30),
+        ];
+        let expected = vec![Interval::new(9, 19)];
+        let set = IntervalSet::from_sorted(intervals).unwrap();
+        let overlaps = set.find_iter_sorted_reciprocal_frac(&query, frac).unwrap();
+        for (i, j) in overlaps.into_iter().zip(expected.iter()) {
+            assert!(i.eq(j))
+        }
+    }
+
+    #[test]
+    fn find_query_frac_unbounded() {
+        let query = Interval::new(10, 20);
+        let set = IntervalSet::from_sorted(vec![Interval::new(0, 10)]).unwrap();
+        assert!(set.find_query_frac(&query, 0.0).is_err());
+        assert!(set.find_query_frac(&query, 1.01).is_err());
+    }
+
+    #[test]
+    fn find_target_frac_unbounded() {
+        let query = Interval::new(10, 20);
+        let set = IntervalSet::from_sorted(vec![Interval::new(0, 10)]).unwrap();
+        assert!(set.find_target_frac(&query, 0.0).is_err());
+        assert!(set.find_target_frac(&query, 1.01).is_err());
+    }
+
+    #[test]
+    fn find_reciprocal_frac_unbounded() {
+        let query = Interval::new(10, 20);
+        let set = IntervalSet::from_sorted(vec![Interval::new(0, 10)]).unwrap();
+        assert!(set.find_reciprocal_frac(&query, 0.0).is_err());
+        assert!(set.find_reciprocal_frac(&query, 1.01).is_err());
     }
 }

--- a/src/traits/container/find.rs
+++ b/src/traits/container/find.rs
@@ -1,7 +1,7 @@
 use super::Container;
 use crate::{
     traits::{errors::SetError, IntervalBounds, ValueBounds},
-    types::{FindIter, FindIterSorted},
+    types::{iterator::QueryMethod, FindIter, FindIterSorted},
     Bound,
 };
 
@@ -25,11 +25,51 @@ where
         Self::ContainerType::new(records)
     }
 
+    /// Finds all intervals that overlap a query by some minimum
+    /// amount and returns the same `Container` type with all found regions.
+    fn find_min(&self, query: &I, minimum: T) -> Self::ContainerType {
+        let records = self
+            .records()
+            .iter()
+            .filter(|x| x.overlaps_by(query, minimum))
+            .map(|x| x.to_owned())
+            .collect();
+        Self::ContainerType::new(records)
+    }
+
+    /// Finds all intervals that overlap a query by some exact
+    /// amount and returns the same `Container` type with all found regions.
+    fn find_exact(&self, query: &I, exact: T) -> Self::ContainerType {
+        let records = self
+            .records()
+            .iter()
+            .filter(|x| x.overlaps_by_exactly(query, exact))
+            .map(|x| x.to_owned())
+            .collect();
+        Self::ContainerType::new(records)
+    }
+
     /// Creates an iterator that finds all overlapping regions
     ///
     /// Does not assume a sorted Container
     fn find_iter<'a>(&'a self, query: &'a I) -> FindIter<'_, T, I> {
-        FindIter::new(self.records(), query)
+        FindIter::new(self.records(), query, QueryMethod::Compare)
+    }
+
+    /// Creates an iterator that finds all overlapping regions
+    /// by some minimum overlap
+    ///
+    /// Does not assume a sorted Container
+    fn find_iter_min<'a>(&'a self, query: &'a I, minimum: T) -> FindIter<'_, T, I> {
+        FindIter::new(self.records(), query, QueryMethod::CompareBy(minimum))
+    }
+
+    /// Creates an iterator that finds all overlapping regions
+    /// by some exact overlap
+    ///
+    /// Does not assume a sorted Container
+    fn find_iter_exact<'a>(&'a self, query: &'a I, exact: T) -> FindIter<'_, T, I> {
+        FindIter::new(self.records(), query, QueryMethod::CompareExact(exact))
     }
 
     /// Creates a Result Iterator that finds all overlapping regions
@@ -43,11 +83,82 @@ where
         }
     }
 
+    /// Creates a Result Iterator that finds all overlapping regions
+    /// by some minimum overlap
+    ///
+    /// First checks to see if container is sorted
+    fn find_iter_sorted_min<'a>(
+        &'a self,
+        query: &'a I,
+        minimum: T,
+    ) -> Result<FindIterSorted<'_, T, I>, SetError> {
+        if self.is_sorted() {
+            Ok(self.find_iter_sorted_min_unchecked(query, minimum))
+        } else {
+            Err(SetError::UnsortedSet)
+        }
+    }
+
+    /// Creates a Result Iterator that finds all overlapping regions
+    /// by some exact overlap
+    ///
+    /// First checks to see if container is sorted
+    fn find_iter_sorted_exact<'a>(
+        &'a self,
+        query: &'a I,
+        exact: T,
+    ) -> Result<FindIterSorted<'_, T, I>, SetError> {
+        if self.is_sorted() {
+            Ok(self.find_iter_sorted_exact_unchecked(query, exact))
+        } else {
+            Err(SetError::UnsortedSet)
+        }
+    }
+
     /// Creates an Iterator that finds all overlapping regions
     ///
     /// Assumes a sorted Container.
     fn find_iter_sorted_unchecked<'a>(&'a self, query: &'a I) -> FindIterSorted<'_, T, I> {
-        FindIterSorted::new(self.records(), query, self.lower_bound_unchecked(query))
+        FindIterSorted::new(
+            self.records(),
+            query,
+            self.lower_bound_unchecked(query),
+            QueryMethod::Compare,
+        )
+    }
+
+    /// Creates an Iterator that finds all overlapping regions
+    /// by some minimum overlap
+    ///
+    /// Assumes a sorted Container.
+    fn find_iter_sorted_min_unchecked<'a>(
+        &'a self,
+        query: &'a I,
+        minimum: T,
+    ) -> FindIterSorted<'_, T, I> {
+        FindIterSorted::new(
+            self.records(),
+            query,
+            self.lower_bound_unchecked(query),
+            QueryMethod::CompareBy(minimum),
+        )
+    }
+
+    /// Creates an Iterator that finds all overlapping regions
+    /// by some exact overlap
+    ///
+    /// Assumes a sorted Container.
+    fn find_iter_sorted_exact_unchecked<'a>(
+        &'a self,
+        query: &'a I,
+        exact: T,
+    ) -> FindIterSorted<'_, T, I> {
+        FindIterSorted::new(
+            self.records(),
+            query,
+            self.lower_bound_unchecked(query),
+            QueryMethod::CompareExact(exact),
+        )
     }
 }
 
@@ -67,6 +178,26 @@ mod testing {
         let set = IntervalSet::from_endpoints_unchecked(&starts, &ends);
         let overlaps = set.find(&query);
         assert_eq!(overlaps.len(), 4);
+    }
+
+    #[test]
+    fn test_find_minimum() {
+        let query = Interval::new(17, 27);
+        let starts = vec![10, 15, 20, 25];
+        let ends = vec![40, 45, 50, 55];
+        let set = IntervalSet::from_endpoints_unchecked(&starts, &ends);
+        let overlaps = set.find_min(&query, 5);
+        assert_eq!(overlaps.len(), 3);
+    }
+
+    #[test]
+    fn test_find_exact() {
+        let query = Interval::new(17, 27);
+        let starts = vec![10, 15, 20, 25];
+        let ends = vec![40, 45, 50, 55];
+        let set = IntervalSet::from_endpoints_unchecked(&starts, &ends);
+        let overlaps = set.find_exact(&query, 7);
+        assert_eq!(overlaps.len(), 1);
     }
 
     #[test]
@@ -98,5 +229,28 @@ mod testing {
         let set = IntervalSet::from_endpoints_unchecked(&starts, &ends);
         let overlaps = set.find_iter_sorted(&query);
         assert!(overlaps.is_err());
+    }
+
+    #[test]
+    fn test_find_iter_min() {
+        let query = Interval::new(17, 27);
+        let starts = vec![10, 15, 20, 25];
+        let ends = vec![40, 45, 50, 55];
+        let set = IntervalSet::from_endpoints_unchecked(&starts, &ends);
+        let overlaps = set.find_iter_min(&query, 5);
+        let num_overlaps = overlaps.count();
+        assert_eq!(num_overlaps, 3);
+    }
+
+    #[test]
+    fn test_find_iter_sorted_min() {
+        let query = Interval::new(17, 27);
+        let starts = vec![10, 15, 20, 25];
+        let ends = vec![40, 45, 50, 55];
+        let mut set = IntervalSet::from_endpoints_unchecked(&starts, &ends);
+        set.sort();
+        let overlaps = set.find_iter_sorted_min(&query, 5).unwrap();
+        let num_overlaps = overlaps.count();
+        assert_eq!(num_overlaps, 3);
     }
 }

--- a/src/traits/container/find.rs
+++ b/src/traits/container/find.rs
@@ -77,6 +77,21 @@ where
         Ok(Self::ContainerType::new(records))
     }
 
+    /// Finds all intervals that overlap a query by some fraction
+    /// of **either** the query and target lengths and returns the
+    /// same `Container` type with all found regions.
+    fn find_reciprocal_frac_either(
+        &self,
+        query: &I,
+        frac: f64,
+    ) -> Result<Self::ContainerType, SetError> {
+        let records = match self.find_iter_reciprocal_frac_either(query, frac) {
+            Ok(iter) => iter.into_iter().map(|x| x.to_owned()).collect::<Vec<I>>(),
+            Err(e) => return Err(e),
+        };
+        Ok(Self::ContainerType::new(records))
+    }
+
     /// Creates an iterator that finds all overlapping regions
     ///
     /// Does not assume a sorted Container
@@ -835,8 +850,8 @@ mod testing {
             Interval::new(15, 18),
         ];
         let set = IntervalSet::from_sorted(intervals).unwrap();
-        let overlaps = set.find_reciprocal_frac(&query, frac).unwrap();
-        for (i, j) in overlaps.records().iter().zip(expected.iter()) {
+        let overlaps = set.find_reciprocal_frac_either(&query, frac).unwrap();
+        for (i, j) in overlaps.records().into_iter().zip(expected.iter()) {
             assert!(i.eq(j))
         }
     }

--- a/src/traits/container/find.rs
+++ b/src/traits/container/find.rs
@@ -429,8 +429,35 @@ where
 mod testing {
     use super::Find;
     use crate::{
-        traits::Container, Coordinates, GenomicInterval, GenomicIntervalSet, Interval, IntervalSet,
+        traits::{Container, IntervalBounds, ValueBounds},
+        GenomicInterval, GenomicIntervalSet, Interval, IntervalSet,
     };
+
+    fn validate_set<C, I, T>(set: &C, expected: &[I])
+    where
+        C: Container<T, I>,
+        I: IntervalBounds<T>,
+        T: ValueBounds,
+    {
+        for idx in 0..expected.len() {
+            let c1 = &set.records()[idx];
+            let c2 = &expected[idx];
+            assert!(c1.eq(c2))
+        }
+    }
+
+    fn validate_iter<I, T>(iter: impl Iterator<Item = I>, expected: &[I])
+    where
+        I: IntervalBounds<T>,
+        T: ValueBounds,
+    {
+        let observed = iter.collect::<Vec<I>>();
+        for idx in 0..expected.len() {
+            let c1 = &observed[idx];
+            let c2 = &expected[idx];
+            assert!(c1.eq(c2))
+        }
+    }
 
     #[test]
     fn find() {
@@ -610,9 +637,7 @@ mod testing {
         ];
         let set = IntervalSet::from_sorted(intervals).unwrap();
         let overlaps = set.find_query_frac(&query, frac).unwrap();
-        for (i, j) in overlaps.records().iter().zip(expected.iter()) {
-            assert!(i.eq(j))
-        }
+        validate_set(&overlaps, &expected);
     }
 
     #[test]
@@ -637,9 +662,7 @@ mod testing {
         ];
         let set = IntervalSet::from_sorted(intervals).unwrap();
         let overlaps = set.find_query_frac(&query, frac).unwrap();
-        for (i, j) in overlaps.records().iter().zip(expected.iter()) {
-            assert!(i.eq(j))
-        }
+        validate_set(&overlaps, &expected);
     }
 
     #[test]
@@ -658,9 +681,7 @@ mod testing {
         let expected = vec![Interval::new(10, 20)];
         let set = IntervalSet::from_sorted(intervals).unwrap();
         let overlaps = set.find_query_frac(&query, frac).unwrap();
-        for (i, j) in overlaps.records().iter().zip(expected.iter()) {
-            assert!(i.eq(j))
-        }
+        validate_set(&overlaps, &expected);
     }
 
     #[test]
@@ -683,10 +704,11 @@ mod testing {
             Interval::new(15, 25),
         ];
         let set = IntervalSet::from_sorted(intervals).unwrap();
-        let overlaps = set.find_iter_sorted_query_frac(&query, frac).unwrap();
-        for (i, j) in overlaps.into_iter().zip(expected.iter()) {
-            assert!(i.eq(j))
-        }
+        let overlap_iter = set
+            .find_iter_sorted_query_frac(&query, frac)
+            .unwrap()
+            .cloned();
+        validate_iter(overlap_iter, &expected);
     }
 
     #[test]
@@ -708,9 +730,7 @@ mod testing {
         ];
         let set = IntervalSet::from_sorted(intervals).unwrap();
         let overlaps = set.find_target_frac(&query, frac).unwrap();
-        for (i, j) in overlaps.records().iter().zip(expected.iter()) {
-            assert!(i.eq(j))
-        }
+        validate_set(&overlaps, &expected)
     }
 
     #[test]
@@ -728,9 +748,7 @@ mod testing {
         let expected = vec![Interval::new(10, 20)];
         let set = IntervalSet::from_sorted(intervals).unwrap();
         let overlaps = set.find_target_frac(&query, frac).unwrap();
-        for (i, j) in overlaps.records().iter().zip(expected.iter()) {
-            assert!(i.eq(j))
-        }
+        validate_set(&overlaps, &expected)
     }
 
     #[test]
@@ -751,9 +769,7 @@ mod testing {
         ];
         let set = IntervalSet::from_sorted(intervals).unwrap();
         let overlaps = set.find_target_frac(&query, frac).unwrap();
-        for (i, j) in overlaps.records().iter().zip(expected.iter()) {
-            assert!(i.eq(j))
-        }
+        validate_set(&overlaps, &expected)
     }
 
     #[test]
@@ -774,10 +790,11 @@ mod testing {
             Interval::new(10, 20),
         ];
         let set = IntervalSet::from_sorted(intervals).unwrap();
-        let overlaps = set.find_iter_sorted_target_frac(&query, frac).unwrap();
-        for (i, j) in overlaps.into_iter().zip(expected.iter()) {
-            assert!(i.eq(j))
-        }
+        let overlap_iter = set
+            .find_iter_sorted_target_frac(&query, frac)
+            .unwrap()
+            .cloned();
+        validate_iter(overlap_iter, &expected);
     }
 
     #[test]
@@ -799,9 +816,7 @@ mod testing {
         let expected = vec![Interval::new(9, 19)];
         let set = IntervalSet::from_sorted(intervals).unwrap();
         let overlaps = set.find_reciprocal_frac(&query, frac).unwrap();
-        for (i, j) in overlaps.records().iter().zip(expected.iter()) {
-            assert!(i.eq(j))
-        }
+        validate_set(&overlaps, &expected)
     }
 
     #[test]
@@ -822,10 +837,11 @@ mod testing {
         ];
         let expected = vec![Interval::new(9, 19)];
         let set = IntervalSet::from_sorted(intervals).unwrap();
-        let overlaps = set.find_iter_sorted_reciprocal_frac(&query, frac).unwrap();
-        for (i, j) in overlaps.into_iter().zip(expected.iter()) {
-            assert!(i.eq(j))
-        }
+        let overlap_iter = set
+            .find_iter_sorted_reciprocal_frac(&query, frac)
+            .unwrap()
+            .cloned();
+        validate_iter(overlap_iter, &expected);
     }
 
     #[test]
@@ -851,9 +867,7 @@ mod testing {
         ];
         let set = IntervalSet::from_sorted(intervals).unwrap();
         let overlaps = set.find_reciprocal_frac_either(&query, frac).unwrap();
-        for (i, j) in overlaps.records().into_iter().zip(expected.iter()) {
-            assert!(i.eq(j))
-        }
+        validate_set(&overlaps, &expected)
     }
 
     #[test]
@@ -878,10 +892,11 @@ mod testing {
             Interval::new(15, 18),
         ];
         let set = IntervalSet::from_sorted(intervals).unwrap();
-        let overlaps = set.find_iter_sorted_reciprocal_frac(&query, frac).unwrap();
-        for (i, j) in overlaps.into_iter().zip(expected.iter()) {
-            assert!(i.eq(j))
-        }
+        let overlap_iter = set
+            .find_iter_sorted_reciprocal_frac_either(&query, frac)
+            .unwrap()
+            .cloned();
+        validate_iter(overlap_iter, &expected);
     }
 
     #[test]

--- a/src/traits/container/find.rs
+++ b/src/traits/container/find.rs
@@ -171,7 +171,7 @@ mod testing {
     };
 
     #[test]
-    fn test_find() {
+    fn find() {
         let query = Interval::new(17, 27);
         let starts = vec![10, 15, 20, 25];
         let ends = vec![40, 45, 50, 55];
@@ -181,7 +181,7 @@ mod testing {
     }
 
     #[test]
-    fn test_find_minimum() {
+    fn find_minimum() {
         let query = Interval::new(17, 27);
         let starts = vec![10, 15, 20, 25];
         let ends = vec![40, 45, 50, 55];
@@ -191,7 +191,7 @@ mod testing {
     }
 
     #[test]
-    fn test_find_exact() {
+    fn find_exact() {
         let query = Interval::new(17, 27);
         let starts = vec![10, 15, 20, 25];
         let ends = vec![40, 45, 50, 55];
@@ -201,7 +201,7 @@ mod testing {
     }
 
     #[test]
-    fn test_find_iter() {
+    fn find_iter() {
         let query = Interval::new(5, 12);
         let starts = vec![10, 15, 20, 25];
         let ends = vec![40, 45, 50, 55];
@@ -211,7 +211,7 @@ mod testing {
     }
 
     #[test]
-    fn test_find_iter_sorted() {
+    fn find_iter_sorted() {
         let query = Interval::new(5, 12);
         let starts = vec![10, 15, 20, 25];
         let ends = vec![40, 45, 50, 55];
@@ -222,7 +222,7 @@ mod testing {
     }
 
     #[test]
-    fn test_find_iter_sorted_wrong_order() {
+    fn find_iter_sorted_wrong_order() {
         let query = Interval::new(5, 12);
         let starts = vec![15, 20, 25, 10];
         let ends = vec![45, 50, 55, 40];
@@ -232,7 +232,7 @@ mod testing {
     }
 
     #[test]
-    fn test_find_iter_min() {
+    fn find_iter_min() {
         let query = Interval::new(17, 27);
         let starts = vec![10, 15, 20, 25];
         let ends = vec![40, 45, 50, 55];
@@ -243,7 +243,7 @@ mod testing {
     }
 
     #[test]
-    fn test_find_iter_exact() {
+    fn find_iter_exact() {
         let query = Interval::new(17, 27);
         let starts = vec![10, 15, 20, 25];
         let ends = vec![40, 45, 50, 55];
@@ -254,7 +254,7 @@ mod testing {
     }
 
     #[test]
-    fn test_find_iter_sorted_min() {
+    fn find_iter_sorted_min() {
         let query = Interval::new(17, 27);
         let starts = vec![10, 15, 20, 25];
         let ends = vec![40, 45, 50, 55];
@@ -266,7 +266,7 @@ mod testing {
     }
 
     #[test]
-    fn test_find_iter_sorted_exact() {
+    fn find_iter_sorted_exact() {
         let query = Interval::new(17, 27);
         let starts = vec![10, 15, 20, 25];
         let ends = vec![40, 45, 50, 55];

--- a/src/traits/container/internal.rs
+++ b/src/traits/container/internal.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use anyhow::{bail, Result};
 
+/// Identifies al non-overlapping intervals within the span of the interval set
 pub trait Internal<T, I>: Container<T, I>
 where
     T: ValueBounds,

--- a/src/traits/container/merge.rs
+++ b/src/traits/container/merge.rs
@@ -141,4 +141,23 @@ mod testing {
         assert_eq!(merge_set.intervals()[0].start(), 10);
         assert_eq!(merge_set.intervals()[0].end(), 40);
     }
+
+    #[test]
+    fn merge_container_methods() {
+        let records = vec![
+            Interval::new(10, 20),
+            Interval::new(20, 30),
+            Interval::new(30, 40),
+        ];
+        let set = IntervalSet::from_sorted_unchecked(records);
+        let mut merge_set = set.merge_unchecked();
+        let mut_records = merge_set.records_mut();
+        assert_eq!(mut_records.len(), 1);
+        assert_eq!(mut_records[0].start(), 10);
+        assert_eq!(mut_records[0].end(), 40);
+        assert!(merge_set.is_sorted());
+        *merge_set.sorted_mut() = false;
+        assert!(!merge_set.is_sorted());
+        assert_eq!(merge_set.max_len(), Some(30));
+    }
 }

--- a/src/traits/errors.rs
+++ b/src/traits/errors.rs
@@ -14,4 +14,7 @@ pub enum SetError {
 
     #[error("Sample size is larger than the number of intervals.")]
     SampleSizeTooLarge,
+
+    #[error("Provided fraction {frac} is oversized. Must be (0, 1]")]
+    FractionUnbounded { frac: f64 },
 }

--- a/src/traits/interval/coordinates.rs
+++ b/src/traits/interval/coordinates.rs
@@ -13,6 +13,9 @@ where
     fn update_end(&mut self, val: &T);
     fn update_chr(&mut self, val: &T);
     fn from(other: &Self) -> Self;
+    fn len(&self) -> T {
+        self.end().sub(self.start())
+    }
     fn update_all(&mut self, chr: &T, start: &T, end: &T) {
         self.update_chr(chr);
         self.update_endpoints(start, end);
@@ -47,6 +50,25 @@ where
             },
             order => order,
         }
+    }
+    fn biased_coord_cmp<I: Coordinates<T>>(&self, other: &I, bias: T) -> Ordering {
+        match self.chr().cmp(&other.chr()) {
+            Ordering::Equal => {
+                let comp = if other.start() < bias {
+                    self.start().cmp(&T::zero())
+                } else {
+                    self.start().cmp(&other.start().sub(bias))
+                };
+                match comp {
+                    Ordering::Equal => self.end().cmp(&other.end()),
+                    order => order,
+                }
+            }
+            order => order,
+        }
+    }
+    fn biased_lt<I: Coordinates<T>>(&self, other: &I, bias: T) -> bool {
+        self.biased_coord_cmp(other, bias) == Ordering::Less
     }
     fn lt<I: Coordinates<T>>(&self, other: &I) -> bool {
         self.coord_cmp(other) == Ordering::Less

--- a/src/traits/interval/overlap.rs
+++ b/src/traits/interval/overlap.rs
@@ -251,6 +251,18 @@ where
     /// (Self)        |--------|
     /// (Other)   |--------|
     /// (n)           |----|
+    ///
+    /// or
+    ///
+    /// (Self)    |--------|
+    /// (Other)     |----|
+    /// (n)         |----|
+    ///
+    /// or
+    ///
+    /// (Self)      |----|
+    /// (Other)   |--------|
+    /// (n)         |----|
     /// ```
     ///
     /// # Example
@@ -269,7 +281,11 @@ where
     /// ```
     fn overlap_size<I: Coordinates<T>>(&self, other: &I) -> Option<T> {
         if self.overlaps(other) {
-            if self.start() > other.start() {
+            if self.contains(other) {
+                Some(other.len())
+            } else if other.contains(self) {
+                Some(self.len())
+            } else if self.start() > other.start() {
                 Some(other.end() - self.start())
             } else {
                 Some(self.end() - other.start())
@@ -360,7 +376,10 @@ where
 #[cfg(test)]
 mod testing {
     use super::Overlap;
-    use crate::types::{record::GenomicInterval, Interval};
+    use crate::{
+        types::{record::GenomicInterval, Interval},
+        Coordinates,
+    };
 
     #[test]
     fn test_overlap_self() {
@@ -602,5 +621,19 @@ mod testing {
         let a = Interval::new(14, 25);
         let b = Interval::new(10, 20);
         assert!(!a.overlaps_by_exactly(&b, 5));
+    }
+
+    #[test]
+    fn overlap_size_contains() {
+        let a = Interval::new(15, 25);
+        let b = Interval::new(17, 23);
+        assert_eq!(a.overlap_size(&b), Some(b.len()));
+    }
+
+    #[test]
+    fn overlap_size_contained_by() {
+        let a = Interval::new(17, 23);
+        let b = Interval::new(15, 25);
+        assert_eq!(a.overlap_size(&b), Some(a.len()));
     }
 }

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,3 +1,4 @@
+use num_traits::Zero;
 use std::{
     fmt::Debug,
     ops::{Add, Div, Mul, Sub},
@@ -20,7 +21,8 @@ where
         + Add<Self, Output = Self>
         + Sub<Self, Output = Self>
         + Mul<Self, Output = Self>
-        + Div<Self, Output = Self>,
+        + Div<Self, Output = Self>
+        + Zero,
 {
 }
 impl<T> ValueBounds for T where
@@ -32,6 +34,7 @@ impl<T> ValueBounds for T where
         + Sub<Self, Output = Self>
         + Mul<Self, Output = Self>
         + Div<Self, Output = Self>
+        + Zero
 {
 }
 

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,8 +1,5 @@
-use num_traits::Zero;
-use std::{
-    fmt::Debug,
-    ops::{Add, Div, Mul, Sub},
-};
+use num_traits::{FromPrimitive, NumOps, ToPrimitive, Zero};
+use std::fmt::Debug;
 
 pub mod container;
 pub mod errors;
@@ -14,27 +11,11 @@ pub use interval::{Coordinates, Intersect, Overlap, Subtract};
 /// Generic bounds for values to be used for [Coordinates]
 pub trait ValueBounds
 where
-    Self: Copy
-        + Default
-        + Ord
-        + Debug
-        + Add<Self, Output = Self>
-        + Sub<Self, Output = Self>
-        + Mul<Self, Output = Self>
-        + Div<Self, Output = Self>
-        + Zero,
+    Self: Copy + Default + Ord + Debug + NumOps + ToPrimitive + FromPrimitive + Zero,
 {
 }
 impl<T> ValueBounds for T where
-    T: Copy
-        + Default
-        + Ord
-        + Debug
-        + Add<Self, Output = Self>
-        + Sub<Self, Output = Self>
-        + Mul<Self, Output = Self>
-        + Div<Self, Output = Self>
-        + Zero
+    T: Copy + Default + Ord + Debug + NumOps + ToPrimitive + FromPrimitive + Zero
 {
 }
 

--- a/src/types/container/genomic_interval_set.rs
+++ b/src/types/container/genomic_interval_set.rs
@@ -237,6 +237,43 @@ mod testing {
     }
 
     #[test]
+    fn test_from_empty_iterator() {
+        let records: Vec<GenomicInterval<usize>> = vec![];
+        let set = GenomicIntervalSet::from_iter(records);
+        assert_eq!(set.len(), 0);
+        assert!(set.max_len().is_none());
+        assert!(set.span().is_err());
+    }
+
+    #[test]
+    fn test_span() {
+        let intervals = vec![
+            GenomicInterval::new(1, 10, 100),
+            GenomicInterval::new(1, 20, 200),
+        ];
+        let set = GenomicIntervalSet::from_sorted(intervals).unwrap();
+        assert_eq!(set.span().unwrap(), GenomicInterval::new(1, 10, 200));
+    }
+
+    #[test]
+    fn test_span_errors() {
+        let intervals = vec![
+            GenomicInterval::new(1, 10, 100),
+            GenomicInterval::new(2, 20, 200),
+        ];
+        let mut set = GenomicIntervalSet::from_iter(intervals);
+        match set.span() {
+            Err(e) => assert_eq!(e.to_string(), "Cannot get span of unsorted interval set"),
+            _ => panic!("Expected error"),
+        };
+        set.sort();
+        match set.span() {
+            Err(e) => assert_eq!(e.to_string(), "Cannot get span of interval set spanning multiple chromosomes"),
+            _ => panic!("Expected error"),
+        };
+    }
+
+    #[test]
     #[cfg(feature = "serde")]
     fn test_serialization() {
         let n_intervals = 10;

--- a/src/types/container/genomic_interval_set.rs
+++ b/src/types/container/genomic_interval_set.rs
@@ -268,7 +268,10 @@ mod testing {
         };
         set.sort();
         match set.span() {
-            Err(e) => assert_eq!(e.to_string(), "Cannot get span of interval set spanning multiple chromosomes"),
+            Err(e) => assert_eq!(
+                e.to_string(),
+                "Cannot get span of interval set spanning multiple chromosomes"
+            ),
             _ => panic!("Expected error"),
         };
     }

--- a/src/types/container/merge.rs
+++ b/src/types/container/merge.rs
@@ -1,5 +1,4 @@
 use crate::traits::{Container, IntervalBounds, ValueBounds};
-use std::marker::PhantomData;
 
 pub struct MergeResults<T, I>
 where
@@ -9,7 +8,7 @@ where
     intervals: Vec<I>,
     clusters: Vec<usize>,
     n_clusters: usize,
-    phantom: PhantomData<T>,
+    max_len: Option<T>,
     is_sorted: bool,
 }
 
@@ -19,11 +18,12 @@ where
     T: ValueBounds,
 {
     fn new(records: Vec<I>) -> Self {
+        let max_len = records.iter().map(|iv| iv.len()).max();
         Self {
             intervals: records,
             clusters: Vec::new(),
             n_clusters: 0,
-            phantom: PhantomData,
+            max_len,
             is_sorted: true,
         }
     }
@@ -39,6 +39,9 @@ where
     fn sorted_mut(&mut self) -> &mut bool {
         &mut self.is_sorted
     }
+    fn max_len(&self) -> Option<T> {
+        self.max_len
+    }
 }
 
 impl<T, I> MergeResults<T, I>
@@ -48,16 +51,22 @@ where
 {
     #[must_use]
     pub fn new(intervals: Vec<I>, clusters: Vec<usize>) -> Self {
+        let max_len = intervals.iter().map(|iv| iv.len()).max();
         let n_clusters = clusters.iter().max().unwrap_or(&0) + 1;
-        Self::from_raw_parts(intervals, clusters, n_clusters)
+        Self::from_raw_parts(intervals, clusters, n_clusters, max_len)
     }
     #[must_use]
-    pub fn from_raw_parts(intervals: Vec<I>, clusters: Vec<usize>, n_clusters: usize) -> Self {
+    pub fn from_raw_parts(
+        intervals: Vec<I>,
+        clusters: Vec<usize>,
+        n_clusters: usize,
+        max_len: Option<T>,
+    ) -> Self {
         Self {
             intervals,
             clusters,
             n_clusters,
-            phantom: PhantomData,
+            max_len,
             is_sorted: true,
         }
     }

--- a/src/types/iterator/find.rs
+++ b/src/types/iterator/find.rs
@@ -7,7 +7,8 @@ pub enum QueryMethod<T: ValueBounds> {
     CompareExact(T),
     CompareByQueryFraction(f64),
     CompareByTargetFraction(f64),
-    CompareReciprocalFraction(f64),
+    CompareReciprocalFractionAnd(f64),
+    CompareReciprocalFractionOr(f64),
 }
 
 /// Calculate the length of an interval as a fraction of its total length
@@ -38,11 +39,20 @@ where
             let min_overlap = f_len(target, *frac);
             target.overlaps_by(query, min_overlap)
         }
-        QueryMethod::CompareReciprocalFraction(frac) => {
+        QueryMethod::CompareReciprocalFractionAnd(frac) => {
             let query_min_overlap = f_len(query, *frac);
             let target_min_overlap = f_len(target, *frac);
             if let Some(ix) = target.overlap_size(query) {
                 query_min_overlap <= ix && target_min_overlap <= ix
+            } else {
+                false
+            }
+        }
+        QueryMethod::CompareReciprocalFractionOr(frac) => {
+            let query_min_overlap = f_len(query, *frac);
+            let target_min_overlap = f_len(target, *frac);
+            if let Some(ix) = target.overlap_size(query) {
+                query_min_overlap <= ix || target_min_overlap <= ix
             } else {
                 false
             }

--- a/src/types/iterator/find.rs
+++ b/src/types/iterator/find.rs
@@ -5,6 +5,49 @@ pub enum QueryMethod<T: ValueBounds> {
     Compare,
     CompareBy(T),
     CompareExact(T),
+    CompareByQueryFraction(f64),
+    CompareByTargetFraction(f64),
+    CompareReciprocalFraction(f64),
+}
+
+/// Calculate the length of an interval as a fraction of its total length
+pub fn f_len<I, T>(interval: &I, frac: f64) -> T
+where
+    I: IntervalBounds<T>,
+    T: ValueBounds,
+{
+    let len_f: f64 = interval.len().to_f64().unwrap();
+    let n = len_f * frac;
+    T::from_f64(n.round()).unwrap()
+}
+
+fn predicate<I, T>(target: &I, query: &I, method: &QueryMethod<T>) -> bool
+where
+    I: IntervalBounds<T>,
+    T: ValueBounds,
+{
+    match method {
+        QueryMethod::Compare => target.overlaps(query),
+        QueryMethod::CompareBy(val) => target.overlaps_by(query, *val),
+        QueryMethod::CompareExact(val) => target.overlaps_by_exactly(query, *val),
+        QueryMethod::CompareByQueryFraction(frac) => {
+            let min_overlap = f_len(query, *frac);
+            target.overlaps_by(query, min_overlap)
+        }
+        QueryMethod::CompareByTargetFraction(frac) => {
+            let min_overlap = f_len(target, *frac);
+            target.overlaps_by(query, min_overlap)
+        }
+        QueryMethod::CompareReciprocalFraction(frac) => {
+            let query_min_overlap = f_len(query, *frac);
+            let target_min_overlap = f_len(target, *frac);
+            if let Some(ix) = target.overlap_size(query) {
+                query_min_overlap <= ix && target_min_overlap <= ix
+            } else {
+                false
+            }
+        }
+    }
 }
 
 pub struct FindIter<'a, T, I>
@@ -32,13 +75,6 @@ where
             method,
         }
     }
-    fn predicate(&self, interval: &I) -> bool {
-        match self.method {
-            QueryMethod::Compare => interval.overlaps(self.query),
-            QueryMethod::CompareBy(val) => interval.overlaps_by(self.query, val),
-            QueryMethod::CompareExact(val) => interval.overlaps_by_exactly(self.query, val),
-        }
-    }
 }
 impl<'a, T, I> Iterator for FindIter<'a, T, I>
 where
@@ -50,7 +86,7 @@ where
         while self.offset < self.inner.len() {
             let interval = &self.inner[self.offset];
             self.offset += 1;
-            if self.predicate(interval) {
+            if predicate(interval, self.query, &self.method) {
                 return Some(interval);
             }
         }
@@ -83,13 +119,6 @@ where
             method,
         }
     }
-    fn predicate(&self, interval: &I) -> bool {
-        match self.method {
-            QueryMethod::Compare => interval.overlaps(self.query),
-            QueryMethod::CompareBy(val) => interval.overlaps_by(self.query, val),
-            QueryMethod::CompareExact(val) => interval.overlaps_by_exactly(self.query, val),
-        }
-    }
 }
 impl<'a, T, I> Iterator for FindIterSorted<'a, T, I>
 where
@@ -101,12 +130,50 @@ where
         while self.offset < self.inner.len() {
             let interval = &self.inner[self.offset];
             self.offset += 1;
-            if self.predicate(interval) {
+            if predicate(interval, self.query, &self.method) {
                 return Some(interval);
             } else if interval.start() >= self.query.end() {
                 break;
             }
         }
         None
+    }
+}
+
+#[cfg(test)]
+mod testing {
+    use super::*;
+    use crate::Interval;
+
+    #[test]
+    fn test_f_len_a() {
+        let interval = Interval::new(0, 100);
+        let frac = 0.5;
+        let len = f_len(&interval, frac);
+        assert_eq!(len, 50);
+    }
+
+    #[test]
+    fn test_f_len_b() {
+        let interval = Interval::new(0, 100);
+        let frac = 0.3;
+        let len = f_len(&interval, frac);
+        assert_eq!(len, 30);
+    }
+
+    #[test]
+    fn test_f_len_c() {
+        let interval = Interval::new(0, 100);
+        let frac = 0.301;
+        let len = f_len(&interval, frac);
+        assert_eq!(len, 30);
+    }
+
+    #[test]
+    fn test_f_len_d() {
+        let interval = Interval::new(0, 100);
+        let frac = 0.299;
+        let len = f_len(&interval, frac);
+        assert_eq!(len, 30);
     }
 }

--- a/src/types/iterator/find.rs
+++ b/src/types/iterator/find.rs
@@ -1,6 +1,12 @@
 use crate::traits::{IntervalBounds, ValueBounds};
 use std::marker::PhantomData;
 
+pub enum QueryMethod<T: ValueBounds> {
+    Compare,
+    CompareBy(T),
+    CompareExact(T),
+}
+
 pub struct FindIter<'a, T, I>
 where
     I: IntervalBounds<T> + 'a,
@@ -10,18 +16,27 @@ where
     query: &'a I,
     offset: usize,
     phantom_t: PhantomData<T>,
+    method: QueryMethod<T>,
 }
 impl<'a, T, I> FindIter<'a, T, I>
 where
     I: IntervalBounds<T>,
     T: ValueBounds,
 {
-    pub fn new(inner: &'a Vec<I>, query: &'a I) -> Self {
+    pub fn new(inner: &'a Vec<I>, query: &'a I, method: QueryMethod<T>) -> Self {
         Self {
             inner,
             query,
             offset: 0,
             phantom_t: PhantomData,
+            method,
+        }
+    }
+    fn predicate(&self, interval: &I) -> bool {
+        match self.method {
+            QueryMethod::Compare => interval.overlaps(self.query),
+            QueryMethod::CompareBy(val) => interval.overlaps_by(self.query, val),
+            QueryMethod::CompareExact(val) => interval.overlaps_by_exactly(self.query, val),
         }
     }
 }
@@ -35,7 +50,7 @@ where
         while self.offset < self.inner.len() {
             let interval = &self.inner[self.offset];
             self.offset += 1;
-            if interval.overlaps(self.query) {
+            if self.predicate(interval) {
                 return Some(interval);
             }
         }
@@ -52,18 +67,27 @@ where
     query: &'a I,
     offset: usize,
     phantom_t: PhantomData<T>,
+    method: QueryMethod<T>,
 }
 impl<'a, T, I> FindIterSorted<'a, T, I>
 where
     I: IntervalBounds<T>,
     T: ValueBounds,
 {
-    pub fn new(inner: &'a Vec<I>, query: &'a I, offset: usize) -> Self {
+    pub fn new(inner: &'a Vec<I>, query: &'a I, offset: usize, method: QueryMethod<T>) -> Self {
         Self {
             inner,
             query,
             offset,
             phantom_t: PhantomData,
+            method,
+        }
+    }
+    fn predicate(&self, interval: &I) -> bool {
+        match self.method {
+            QueryMethod::Compare => interval.overlaps(self.query),
+            QueryMethod::CompareBy(val) => interval.overlaps_by(self.query, val),
+            QueryMethod::CompareExact(val) => interval.overlaps_by_exactly(self.query, val),
         }
     }
 }
@@ -77,7 +101,7 @@ where
         while self.offset < self.inner.len() {
             let interval = &self.inner[self.offset];
             self.offset += 1;
-            if interval.overlaps(self.query) {
+            if self.predicate(interval) {
                 return Some(interval);
             } else if interval.start() >= self.query.end() {
                 break;

--- a/src/types/iterator/mod.rs
+++ b/src/types/iterator/mod.rs
@@ -1,4 +1,4 @@
 mod find;
 mod subtract;
-pub use find::{FindIter, FindIterSorted};
+pub use find::{FindIter, FindIterSorted, QueryMethod};
 pub use subtract::{SubtractFromIter, SubtractIter};

--- a/src/types/iterator/mod.rs
+++ b/src/types/iterator/mod.rs
@@ -1,4 +1,4 @@
 mod find;
 mod subtract;
-pub use find::{FindIter, FindIterSorted, QueryMethod};
+pub use find::{f_len, FindIter, FindIterSorted, QueryMethod};
 pub use subtract::{SubtractFromIter, SubtractIter};


### PR DESCRIPTION
some large changes with this one:

## Fixing Bounds Calculation
- added a `max-len` attribute to containers for use in the lower bound binary search tree
- fixed bug in lower bound calculation by informing the search by the maximum interval size of the container

## Adding more specific find methods to Find container trait
- added more specific find methods to the Find container trait
    - find by minimum overlap (discrete)
    - find by exact overlap (discrete)
    - find by minimum query overlap (fractional)
    - find by minimum target overlap (fractional)
    - find by minimum reciprocal overlap AND (fractional) 
    - find by minimum reciprocal overlap  OR (fractional)

## Trait conditions
- using `num_traits` crate for trait bounds to clean up ValueBounds conditions
- lets us translate between primitives more easily