### PR TITLE
104 introduce stranded overlap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bedrs"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 license = "MIT"
 description = "Genomic interval library in rust"

--- a/justfile
+++ b/justfile
@@ -1,0 +1,13 @@
+test: test-library test-docs
+
+test-library:
+  cargo nextest run --all-features
+
+test-docs:
+  cargo test --doc
+
+build:
+  cargo build --release
+
+coverage:
+  cargo llvm-cov nextest --html --open

--- a/src/traits/container/bound.rs
+++ b/src/traits/container/bound.rs
@@ -161,6 +161,23 @@ where
         }
     }
 
+    /// Finds the latest record in the [Container] that shares a chromosome
+    /// and a strand with the query and is upstream. Can result in an error if
+    /// the [Container] is not sorted.
+    ///
+    /// Will return `None` if no record shares a chromosome and a strand with
+    /// the query and is upstream.
+    fn stranded_upstream_bound(&self, query: &I) -> Result<Option<usize>, SetError> {
+        if self.is_sorted() {
+            if self.records().is_empty() {
+                return Err(SetError::EmptySet);
+            }
+            Ok(self.stranded_upstream_bound_unchecked(query))
+        } else {
+            Err(SetError::UnsortedSet)
+        }
+    }
+
     /// Finds the earliest record in the [Container] that shares a chromosome
     /// with the query and is downstream. Can result in an error if the [Container]
     /// is not sorted.
@@ -173,6 +190,23 @@ where
                 return Err(SetError::EmptySet);
             }
             Ok(self.chr_bound_downstream_unchecked(query))
+        } else {
+            Err(SetError::UnsortedSet)
+        }
+    }
+
+    /// Finds the earliest record in the [Container] that shares a chromosome
+    /// and a strand with the query and is downstream. Can result in an error if
+    /// the [Container] is not sorted.
+    ///
+    /// Will return `None` if no record shares a chromosome and a strand with
+    /// the query and is downstream.
+    fn stranded_downstream_bound(&self, query: &I) -> Result<Option<usize>, SetError> {
+        if self.is_sorted() {
+            if self.records().is_empty() {
+                return Err(SetError::EmptySet);
+            }
+            Ok(self.stranded_downstream_bound_unchecked(query))
         } else {
             Err(SetError::UnsortedSet)
         }
@@ -254,6 +288,51 @@ where
         }
     }
 
+    fn stranded_upstream_bound_unchecked(&self, query: &I) -> Option<usize> {
+        // partition point returns the first index in the slice for which
+        // the predicate fails (i.e. the index of the first record that is
+        // greater than the query).
+        let low = self
+            .records()
+            .partition_point(|iv| iv.lt(query) && iv.bounded_strand(query));
+
+        // If the low index is 0, then the query is potentially less than
+        // all records in the set.
+        if low == 0 {
+            let target = &self.records()[0];
+
+            // If the first record in the set has the same chromosome as the
+            // query and the start of the record is less than or equal to the
+            // start of the query, and they share a strand then return 0.
+            if target.chr() == query.chr()
+                && target.start() <= query.start()
+                && target.strand() == query.strand()
+            {
+                Some(0)
+            } else {
+                None
+            }
+        } else {
+            // otherwise the low index is the index of the first record that
+            // is greater than the query. We subtract 1 to get the index of
+            // the last record that is less than the query.
+            let idx = low - 1;
+
+            // If the record at the index has the same chromosome as the
+            // query and they share a strand then return the index.
+            if self.records()[idx].chr() == query.chr()
+                && self.records()[idx].strand() == query.strand()
+            {
+                Some(idx)
+
+            // Otherwise, the query is less than all records in the set
+            // that share a chromosome and strand.
+            } else {
+                None
+            }
+        }
+    }
+
     /// Finds the earliest record in the [Container] that shares a chromosome
     /// and is downstream of the query. Does not perform a check if it is
     /// sorted beforehand. Use at your own risk.
@@ -288,13 +367,65 @@ where
             Some(low)
         }
     }
+
+    /// Finds the earliest record in the [Container] that shares a chromosome
+    /// and is downstream of the query and shares a strand. Does not perform a check if it is
+    /// sorted beforehand. Use at your own risk.
+    fn stranded_downstream_bound_unchecked(&self, query: &I) -> Option<usize> {
+        // partition point returns the first index in the slice for which
+        // the predicate fails (i.e. the index of the first record that is
+        // greater than the query).
+        let lt_bound = self.records().partition_point(|iv| iv.lt(query));
+
+        // Iterate from the low bound to the end of the set and find the first
+        // record that shares a strand with the query.
+        // This will short-circuit on the first record that does not share a
+        // chromosome.
+        let strand_bound = self.records()[lt_bound..]
+            .iter()
+            .enumerate()
+            .take_while(|(_, iv)| iv.bounded_chr(query))
+            .filter(|(_, iv)| iv.bounded_strand(query))
+            .next()?
+            .0;
+
+        let low = lt_bound + strand_bound;
+
+        // If the low index is the length of the set, then the query is
+        // greater than all records in the set.
+        if low == self.len() {
+            None
+
+        // If the low index is 0, then the query is potentially less than
+        // all records in the set.
+        } else if low == 0 {
+            // If the first record in the set has the same chromosome as the
+            // query and shares a strand, then return 0.
+            if self.records()[0].chr() == query.chr()
+                && self.records()[0].strand() == query.strand()
+            {
+                Some(0)
+
+            // Otherwise, the query is less than all records in the set.
+            } else {
+                None
+            }
+        }
+        // If the low index is not 0 or the length of the set, then the query
+        // shares a chromosome and strand with at least one record in the set.
+        // Returns the earliest index of a record with the same chromosome
+        else {
+            Some(low)
+        }
+    }
 }
 
 #[cfg(test)]
 mod testing {
     use crate::{
-        traits::errors::SetError, Bound, Container, GenomicInterval, GenomicIntervalSet, Interval,
-        IntervalSet,
+        traits::errors::SetError, types::StrandedGenomicIntervalSet, Bound, Container,
+        GenomicInterval, GenomicIntervalSet, Interval, IntervalSet, Strand,
+        StrandedGenomicInterval,
     };
 
     #[test]
@@ -325,6 +456,28 @@ mod testing {
     }
 
     #[test]
+    fn bsearch_unsorted_stranded_upstream() {
+        let records = (0..500)
+            .map(|x| StrandedGenomicInterval::new(1, x, x + 50, Strand::Forward))
+            .collect();
+        let set = StrandedGenomicIntervalSet::new(records);
+        let query = StrandedGenomicInterval::new(1, 10, 20, Strand::Forward);
+        let bound = set.stranded_upstream_bound(&query);
+        assert!(bound.is_err());
+    }
+
+    #[test]
+    fn bsearch_unsorted_stranded_downstream() {
+        let records = (0..500)
+            .map(|x| StrandedGenomicInterval::new(1, x, x + 50, Strand::Forward))
+            .collect();
+        let set = StrandedGenomicIntervalSet::new(records);
+        let query = StrandedGenomicInterval::new(1, 10, 20, Strand::Forward);
+        let bound = set.stranded_downstream_bound(&query);
+        assert!(bound.is_err());
+    }
+
+    #[test]
     fn bsearch_empty_chr() {
         let records = Vec::new();
         let set = IntervalSet::new(records);
@@ -348,6 +501,24 @@ mod testing {
         let set = IntervalSet::new(records);
         let query = Interval::new(10, 20);
         let bound = set.chr_bound_downstream(&query);
+        assert!(bound.is_err());
+    }
+
+    #[test]
+    fn bsearch_empty_chr_stranded_upstream() {
+        let records = Vec::new();
+        let set = StrandedGenomicIntervalSet::new(records);
+        let query = StrandedGenomicInterval::new(1, 10, 20, Strand::Forward);
+        let bound = set.stranded_upstream_bound(&query);
+        assert!(bound.is_err());
+    }
+
+    #[test]
+    fn bsearch_empty_chr_stranded_downstream() {
+        let records = Vec::new();
+        let set = StrandedGenomicIntervalSet::new(records);
+        let query = StrandedGenomicInterval::new(1, 10, 20, Strand::Forward);
+        let bound = set.stranded_downstream_bound(&query);
         assert!(bound.is_err());
     }
 
@@ -701,6 +872,63 @@ mod testing {
     }
 
     #[test]
+    fn bsearch_chr_upstream_a_stranded() {
+        let intervals = vec![
+            StrandedGenomicInterval::new(1, 0, 300, Strand::Forward),
+            StrandedGenomicInterval::new(2, 0, 300, Strand::Forward),
+            StrandedGenomicInterval::new(2, 16, 316, Strand::Forward), // <- closest
+            StrandedGenomicInterval::new(2, 16, 316, Strand::Reverse), // <- wrong strand
+            StrandedGenomicInterval::new(2, 16, 316, Strand::Unknown), // <- wrong strand
+            StrandedGenomicInterval::new(3, 53, 353, Strand::Forward),
+        ];
+        let query = StrandedGenomicInterval::new(2, 100, 300, Strand::Forward);
+        let set = StrandedGenomicIntervalSet::from_unsorted(intervals);
+        let bound = set.stranded_upstream_bound(&query).unwrap();
+        assert_eq!(bound, Some(2));
+    }
+
+    #[test]
+    fn bsearch_chr_upstream_b_stranded() {
+        let intervals = vec![
+            StrandedGenomicInterval::new(1, 0, 300, Strand::Forward),
+            StrandedGenomicInterval::new(2, 0, 300, Strand::Forward), // <- closest
+            StrandedGenomicInterval::new(2, 16, 316, Strand::Reverse), // <- wrong strand
+            StrandedGenomicInterval::new(3, 53, 353, Strand::Forward),
+        ];
+        let query = StrandedGenomicInterval::new(2, 100, 300, Strand::Forward);
+        let set = StrandedGenomicIntervalSet::from_unsorted(intervals);
+        let bound = set.stranded_upstream_bound(&query).unwrap();
+        assert_eq!(bound, Some(1));
+    }
+
+    #[test]
+    fn bsearch_chr_upstream_c_stranded() {
+        let intervals = vec![
+            StrandedGenomicInterval::new(1, 0, 300, Strand::Forward),
+            StrandedGenomicInterval::new(2, 16, 316, Strand::Reverse), // <- wrong strand
+            StrandedGenomicInterval::new(3, 53, 353, Strand::Forward),
+        ];
+        let query = StrandedGenomicInterval::new(2, 100, 300, Strand::Forward);
+        let set = StrandedGenomicIntervalSet::from_unsorted(intervals);
+        let bound = set.stranded_upstream_bound(&query).unwrap();
+        assert_eq!(bound, None);
+    }
+
+    #[test]
+    fn bsearch_chr_upstream_d_stranded() {
+        let intervals = vec![
+            StrandedGenomicInterval::new(1, 0, 300, Strand::Forward),
+            StrandedGenomicInterval::new(2, 0, 300, Strand::Reverse), // <- wrong strand
+            StrandedGenomicInterval::new(2, 16, 316, Strand::Forward), // <- min
+            StrandedGenomicInterval::new(3, 53, 353, Strand::Forward),
+        ];
+        let query = StrandedGenomicInterval::new(2, 100, 300, Strand::Forward);
+        let set = StrandedGenomicIntervalSet::from_unsorted(intervals);
+        let bound = set.stranded_upstream_bound(&query).unwrap();
+        assert_eq!(bound, Some(2));
+    }
+
+    #[test]
     fn bsearch_chr_downstream_a() {
         let intervals = vec![
             GenomicInterval::new(1, 0, 300),
@@ -779,5 +1007,82 @@ mod testing {
         let query = GenomicInterval::new(0, 12, 15);
         let bound = set.chr_bound_downstream(&query).unwrap().unwrap();
         assert_eq!(bound, 4);
+    }
+
+    #[test]
+    fn bsearch_stranded_downstream_a() {
+        let intervals = vec![
+            StrandedGenomicInterval::new(1, 0, 300, Strand::Forward),
+            StrandedGenomicInterval::new(2, 0, 300, Strand::Forward),
+            StrandedGenomicInterval::new(2, 16, 316, Strand::Forward), // <- min
+            StrandedGenomicInterval::new(2, 16, 316, Strand::Reverse), // <- wrong-strand
+            StrandedGenomicInterval::new(3, 53, 353, Strand::Forward),
+        ];
+        let query = StrandedGenomicInterval::new(2, 10, 300, Strand::Forward);
+        let set = StrandedGenomicIntervalSet::from_unsorted(intervals);
+        let bound = set.stranded_downstream_bound(&query).unwrap();
+        assert_eq!(bound, Some(2));
+    }
+
+    #[test]
+    fn bsearch_stranded_downstream_b() {
+        let intervals = vec![
+            StrandedGenomicInterval::new(1, 0, 300, Strand::Forward),
+            StrandedGenomicInterval::new(2, 0, 300, Strand::Forward),
+            StrandedGenomicInterval::new(2, 16, 316, Strand::Reverse), // <- wrong-strand
+            StrandedGenomicInterval::new(2, 116, 316, Strand::Forward), // <- min
+            StrandedGenomicInterval::new(3, 53, 353, Strand::Forward),
+        ];
+        let query = StrandedGenomicInterval::new(2, 10, 300, Strand::Forward);
+        let set = StrandedGenomicIntervalSet::from_unsorted(intervals);
+        let bound = set.stranded_downstream_bound(&query).unwrap();
+        assert_eq!(bound, Some(3));
+    }
+
+    #[test]
+    fn bsearch_stranded_downstream_c() {
+        let intervals = vec![
+            StrandedGenomicInterval::new(1, 0, 300, Strand::Forward),
+            StrandedGenomicInterval::new(2, 0, 300, Strand::Forward),
+            StrandedGenomicInterval::new(2, 16, 316, Strand::Reverse), // <- wrong-strand
+            StrandedGenomicInterval::new(2, 16, 316, Strand::Unknown), // <- wrong-strand
+            StrandedGenomicInterval::new(2, 116, 316, Strand::Forward), // <- min
+            StrandedGenomicInterval::new(3, 53, 353, Strand::Forward),
+        ];
+        let query = StrandedGenomicInterval::new(2, 10, 300, Strand::Forward);
+        let set = StrandedGenomicIntervalSet::from_unsorted(intervals);
+        let bound = set.stranded_downstream_bound(&query).unwrap();
+        assert_eq!(bound, Some(4));
+    }
+
+    #[test]
+    fn bsearch_stranded_downstream_d() {
+        let intervals = vec![
+            StrandedGenomicInterval::new(1, 0, 300, Strand::Forward),
+            StrandedGenomicInterval::new(2, 0, 300, Strand::Forward),
+            StrandedGenomicInterval::new(2, 16, 316, Strand::Reverse), // <- wrong-strand
+            StrandedGenomicInterval::new(2, 16, 316, Strand::Unknown), // <- wrong-strand
+            StrandedGenomicInterval::new(2, 116, 316, Strand::Reverse), // <- wrong-strand
+            StrandedGenomicInterval::new(3, 53, 353, Strand::Forward),
+        ];
+        let query = StrandedGenomicInterval::new(2, 10, 300, Strand::Forward);
+        let set = StrandedGenomicIntervalSet::from_unsorted(intervals);
+        let bound = set.stranded_downstream_bound(&query).unwrap();
+        assert_eq!(bound, None);
+    }
+
+    #[test]
+    fn bsearch_stranded_downstream_e() {
+        let intervals = vec![
+            StrandedGenomicInterval::new(2, 0, 300, Strand::Forward), // <- wrong-chr
+            StrandedGenomicInterval::new(2, 16, 316, Strand::Reverse), // <- wrong-strand
+            StrandedGenomicInterval::new(2, 16, 316, Strand::Unknown), // <- wrong-strand
+            StrandedGenomicInterval::new(2, 116, 316, Strand::Reverse), // <- wrong-strand
+            StrandedGenomicInterval::new(3, 53, 353, Strand::Forward),
+        ];
+        let query = StrandedGenomicInterval::new(1, 10, 300, Strand::Forward);
+        let set = StrandedGenomicIntervalSet::from_unsorted(intervals);
+        let bound = set.stranded_downstream_bound(&query).unwrap();
+        assert_eq!(bound, None);
     }
 }

--- a/src/traits/interval/coordinates.rs
+++ b/src/traits/interval/coordinates.rs
@@ -1,6 +1,6 @@
 use crate::{
     traits::{ChromBounds, ValueBounds},
-    Intersect, Overlap, Subtract,
+    Intersect, Overlap, Strand, Subtract,
 };
 use std::cmp::Ordering;
 
@@ -15,6 +15,15 @@ where
     fn start(&self) -> T;
     fn end(&self) -> T;
     fn chr(&self) -> &C;
+
+    /// Return the strand of the interval, if it has one.
+    ///
+    /// This is a default implementation that returns `None` for
+    /// intervals that do not have a strand.
+    fn strand(&self) -> Option<Strand> {
+        None
+    }
+
     fn update_start(&mut self, val: &T);
     fn update_end(&mut self, val: &T);
     fn update_chr(&mut self, val: &C);

--- a/src/traits/interval/coordinates.rs
+++ b/src/traits/interval/coordinates.rs
@@ -60,7 +60,10 @@ where
     fn coord_cmp<I: Coordinates<C, T>>(&self, other: &I) -> Ordering {
         match self.chr().cmp(&other.chr()) {
             Ordering::Equal => match self.start().cmp(&other.start()) {
-                Ordering::Equal => self.end().cmp(&other.end()),
+                Ordering::Equal => match self.end().cmp(&other.end()) {
+                    Ordering::Equal => self.strand().cmp(&other.strand()),
+                    order => order,
+                },
                 order => order,
             },
             order => order,
@@ -81,7 +84,10 @@ where
                 };
                 if let Some(comp) = comp {
                     match comp {
-                        Ordering::Equal => self.end().cmp(&other.end()),
+                        Ordering::Equal => match self.end().cmp(&other.end()) {
+                            Ordering::Equal => self.strand().cmp(&other.strand()),
+                            order => order,
+                        },
                         order => order,
                     }
                 } else {

--- a/src/traits/interval/intersect.rs
+++ b/src/traits/interval/intersect.rs
@@ -38,12 +38,38 @@ where
             None
         }
     }
+
+    /// Calculates the intersection between two coordinates if they overlap
+    /// and are on the same strand.
+    ///
+    /// ```
+    /// use bedrs::{Coordinates, Intersect, StrandedGenomicInterval, Strand};
+    ///
+    /// let a = StrandedGenomicInterval::new(1, 10, 20, Strand::Forward);
+    /// let b = StrandedGenomicInterval::new(1, 15, 25, Strand::Forward);
+    /// let c = StrandedGenomicInterval::new(1, 15, 25, Strand::Reverse);
+    ///
+    /// let ix = a.stranded_intersect(&b).unwrap();
+    /// assert_eq!(ix.start(), 15);
+    /// assert_eq!(ix.end(), 20);
+    /// assert_eq!(ix.strand(), Some(Strand::Forward));
+    ///
+    /// assert!(a.stranded_intersect(&c).is_none());
+    /// ```
+    fn stranded_intersect<I: Coordinates<C, T>>(&self, other: &I) -> Option<I> {
+        if self.stranded_overlaps(other) {
+            let ix = self.build_intersection_interval(other);
+            Some(ix)
+        } else {
+            None
+        }
+    }
 }
 
 #[cfg(test)]
 mod testing {
     use super::Intersect;
-    use crate::{Coordinates, Interval};
+    use crate::{Coordinates, GenomicInterval, Interval, Strand, StrandedGenomicInterval};
 
     #[test]
     ///       x-------y
@@ -56,6 +82,33 @@ mod testing {
         let ix = a.intersect(&b).unwrap();
         assert_eq!(ix.start(), 20);
         assert_eq!(ix.end(), 25);
+    }
+
+    #[test]
+    fn intersection_case_a_genomic() {
+        let a = GenomicInterval::new(1, 20, 30);
+        let b = GenomicInterval::new(1, 15, 25);
+        let c = GenomicInterval::new(2, 15, 25);
+        let ix = a.intersect(&b).unwrap();
+        assert_eq!(ix.start(), 20);
+        assert_eq!(ix.end(), 25);
+        assert!(a.intersect(&c).is_none());
+    }
+
+    #[test]
+    fn intersection_case_a_stranded() {
+        let a = StrandedGenomicInterval::new(1, 20, 30, Strand::Forward);
+        let b = StrandedGenomicInterval::new(1, 15, 25, Strand::Forward);
+        let c = StrandedGenomicInterval::new(1, 15, 25, Strand::Reverse);
+        let d = StrandedGenomicInterval::new(2, 15, 25, Strand::Forward);
+        let e = StrandedGenomicInterval::new(2, 15, 25, Strand::Reverse);
+        let ix = a.stranded_intersect(&b).unwrap();
+        assert_eq!(ix.start(), 20);
+        assert_eq!(ix.end(), 25);
+        assert_eq!(ix.strand(), Some(Strand::Forward));
+        assert!(a.stranded_intersect(&c).is_none());
+        assert!(a.stranded_intersect(&d).is_none());
+        assert!(a.stranded_intersect(&e).is_none());
     }
 
     #[test]
@@ -72,6 +125,33 @@ mod testing {
     }
 
     #[test]
+    fn intersection_case_b_genomic() {
+        let a = GenomicInterval::new(1, 20, 30);
+        let b = GenomicInterval::new(1, 25, 35);
+        let c = GenomicInterval::new(2, 25, 35);
+        let ix = a.intersect(&b).unwrap();
+        assert_eq!(ix.start(), 25);
+        assert_eq!(ix.end(), 30);
+        assert!(a.intersect(&c).is_none());
+    }
+
+    #[test]
+    fn intersection_case_b_stranded() {
+        let a = StrandedGenomicInterval::new(1, 20, 30, Strand::Forward);
+        let b = StrandedGenomicInterval::new(1, 25, 35, Strand::Forward);
+        let c = StrandedGenomicInterval::new(1, 25, 35, Strand::Reverse);
+        let d = StrandedGenomicInterval::new(2, 25, 35, Strand::Forward);
+        let e = StrandedGenomicInterval::new(2, 25, 35, Strand::Reverse);
+        let ix = a.stranded_intersect(&b).unwrap();
+        assert_eq!(ix.start(), 25);
+        assert_eq!(ix.end(), 30);
+        assert_eq!(ix.strand(), Some(Strand::Forward));
+        assert!(a.stranded_intersect(&c).is_none());
+        assert!(a.stranded_intersect(&d).is_none());
+        assert!(a.stranded_intersect(&e).is_none());
+    }
+
+    #[test]
     ///    x--------y
     ///       i--j
     /// ==================
@@ -82,6 +162,33 @@ mod testing {
         let ix = a.intersect(&b).unwrap();
         assert_eq!(ix.start(), 25);
         assert_eq!(ix.end(), 35);
+    }
+
+    #[test]
+    fn intersection_case_c_genomic() {
+        let a = GenomicInterval::new(1, 20, 40);
+        let b = GenomicInterval::new(1, 25, 35);
+        let c = GenomicInterval::new(2, 25, 35);
+        let ix = a.intersect(&b).unwrap();
+        assert_eq!(ix.start(), 25);
+        assert_eq!(ix.end(), 35);
+        assert!(a.intersect(&c).is_none());
+    }
+
+    #[test]
+    fn intersection_case_c_stranded() {
+        let a = StrandedGenomicInterval::new(1, 20, 40, Strand::Forward);
+        let b = StrandedGenomicInterval::new(1, 25, 35, Strand::Forward);
+        let c = StrandedGenomicInterval::new(1, 25, 35, Strand::Reverse);
+        let d = StrandedGenomicInterval::new(2, 25, 35, Strand::Forward);
+        let e = StrandedGenomicInterval::new(2, 25, 35, Strand::Reverse);
+        let ix = a.stranded_intersect(&b).unwrap();
+        assert_eq!(ix.start(), 25);
+        assert_eq!(ix.end(), 35);
+        assert_eq!(ix.strand(), Some(Strand::Forward));
+        assert!(a.stranded_intersect(&c).is_none());
+        assert!(a.stranded_intersect(&d).is_none());
+        assert!(a.stranded_intersect(&e).is_none());
     }
 
     #[test]
@@ -98,6 +205,33 @@ mod testing {
     }
 
     #[test]
+    fn intersection_case_d_genomic() {
+        let a = GenomicInterval::new(1, 25, 35);
+        let b = GenomicInterval::new(1, 20, 40);
+        let c = GenomicInterval::new(2, 20, 40);
+        let ix = a.intersect(&b).unwrap();
+        assert_eq!(ix.start(), 25);
+        assert_eq!(ix.end(), 35);
+        assert!(a.intersect(&c).is_none());
+    }
+
+    #[test]
+    fn intersection_case_d_stranded() {
+        let a = StrandedGenomicInterval::new(1, 25, 35, Strand::Forward);
+        let b = StrandedGenomicInterval::new(1, 20, 40, Strand::Forward);
+        let c = StrandedGenomicInterval::new(1, 20, 40, Strand::Reverse);
+        let d = StrandedGenomicInterval::new(2, 20, 40, Strand::Forward);
+        let e = StrandedGenomicInterval::new(2, 20, 40, Strand::Reverse);
+        let ix = a.stranded_intersect(&b).unwrap();
+        assert_eq!(ix.start(), 25);
+        assert_eq!(ix.end(), 35);
+        assert_eq!(ix.strand(), Some(Strand::Forward));
+        assert!(a.stranded_intersect(&c).is_none());
+        assert!(a.stranded_intersect(&d).is_none());
+        assert!(a.stranded_intersect(&e).is_none());
+    }
+
+    #[test]
     ///       x--y
     ///       i--j
     /// ==================
@@ -111,6 +245,33 @@ mod testing {
     }
 
     #[test]
+    fn intersection_case_e_genomic() {
+        let a = GenomicInterval::new(1, 20, 40);
+        let b = GenomicInterval::new(1, 20, 40);
+        let c = GenomicInterval::new(2, 20, 40);
+        let ix = a.intersect(&b).unwrap();
+        assert_eq!(ix.start(), 20);
+        assert_eq!(ix.end(), 40);
+        assert!(a.intersect(&c).is_none());
+    }
+
+    #[test]
+    fn intersection_case_e_stranded() {
+        let a = StrandedGenomicInterval::new(1, 20, 40, Strand::Forward);
+        let b = StrandedGenomicInterval::new(1, 20, 40, Strand::Forward);
+        let c = StrandedGenomicInterval::new(1, 20, 40, Strand::Reverse);
+        let d = StrandedGenomicInterval::new(2, 20, 40, Strand::Forward);
+        let e = StrandedGenomicInterval::new(2, 20, 40, Strand::Reverse);
+        let ix = a.stranded_intersect(&b).unwrap();
+        assert_eq!(ix.start(), 20);
+        assert_eq!(ix.end(), 40);
+        assert_eq!(ix.strand(), Some(Strand::Forward));
+        assert!(a.stranded_intersect(&c).is_none());
+        assert!(a.stranded_intersect(&d).is_none());
+        assert!(a.stranded_intersect(&e).is_none());
+    }
+
+    #[test]
     ///    x--y
     ///         i--j
     /// ==================
@@ -120,5 +281,27 @@ mod testing {
         let b = Interval::new(20, 25);
         let ix = a.intersect(&b);
         assert!(ix.is_none());
+    }
+
+    #[test]
+    fn intersection_case_none_genomic() {
+        let a = GenomicInterval::new(1, 10, 15);
+        let b = GenomicInterval::new(1, 20, 25);
+        let c = GenomicInterval::new(2, 20, 25);
+        assert!(a.intersect(&b).is_none());
+        assert!(a.intersect(&c).is_none());
+    }
+
+    #[test]
+    fn intersection_case_none_stranded() {
+        let a = StrandedGenomicInterval::new(1, 10, 15, Strand::Forward);
+        let b = StrandedGenomicInterval::new(1, 20, 25, Strand::Forward);
+        let c = StrandedGenomicInterval::new(1, 20, 25, Strand::Reverse);
+        let d = StrandedGenomicInterval::new(2, 20, 25, Strand::Forward);
+        let e = StrandedGenomicInterval::new(2, 20, 25, Strand::Reverse);
+        assert!(a.stranded_intersect(&b).is_none());
+        assert!(a.stranded_intersect(&c).is_none());
+        assert!(a.stranded_intersect(&d).is_none());
+        assert!(a.stranded_intersect(&e).is_none());
     }
 }

--- a/src/traits/interval/overlap.rs
+++ b/src/traits/interval/overlap.rs
@@ -31,6 +31,31 @@ where
         other.chr() == self.chr()
     }
 
+    /// Returns true if the two intervals are on the same strand.
+    ///
+    /// ``` text
+    /// (Self)     |--------->
+    /// (Other)       |--------->
+    /// ====================================
+    /// true
+    ///
+    /// (Self)     <---------|
+    /// (Other)        <---------|
+    /// ====================================
+    /// true
+    ///
+    /// (Self)     |--------->
+    /// (Other)        <---------|
+    /// ====================================
+    /// false
+    /// ```
+    fn bounded_strand<I: Coordinates<C, T>>(&self, other: &I) -> bool {
+        match (self.strand(), other.strand()) {
+            (Some(s1), Some(s2)) => s1 == s2,
+            _ => true,
+        }
+    }
+
     /// Returns true if the two intervals overlap.
     ///
     /// Does not consider the chromosome.
@@ -165,6 +190,27 @@ where
         self.bounded_chr(other) && self.interval_overlap(other)
     }
 
+    /// Returns true if the current interval overlaps the other
+    /// and both intervals are on the same chromosome and strand.
+    ///
+    /// Considers all three of:
+    /// 1. The chromosome
+    /// 2. The strand
+    /// 3. The interval overlap
+    ///
+    /// ```text
+    /// (Self)    |-------->
+    /// (Other)       |-------->
+    ///
+    /// or
+    ///
+    /// (Self)        <--------|
+    /// (Other)   <--------|
+    /// ```
+    fn stranded_overlaps<I: Coordinates<C, T>>(&self, other: &I) -> bool {
+        self.bounded_chr(other) && self.bounded_strand(other) && self.interval_overlap(other)
+    }
+
     /// Returns true if the current interval is overlapped by the other
     /// for the requested number of bases - considers both the interval
     /// overlap and the chromosome.
@@ -202,6 +248,11 @@ where
         self.overlap_size(other).map_or(false, |n| n >= bases)
     }
 
+    fn stranded_overlaps_by<I: Coordinates<C, T>>(&self, other: &I, bases: T) -> bool {
+        self.stranded_overlap_size(other)
+            .map_or(false, |n| n >= bases)
+    }
+
     /// Returns true if the current interval is overlapped by the other
     /// by the exact number of bases - considers both the interval overlap
     /// and the chromosome.
@@ -236,6 +287,11 @@ where
     /// ```
     fn overlaps_by_exactly<I: Coordinates<C, T>>(&self, other: &I, bases: T) -> bool {
         self.overlap_size(other).map_or(false, |n| n == bases)
+    }
+
+    fn stranded_overlaps_by_exactly<I: Coordinates<C, T>>(&self, other: &I, bases: T) -> bool {
+        self.stranded_overlap_size(other)
+            .map_or(false, |n| n == bases)
     }
 
     /// Returns the number of bases overlapped by the other interval -
@@ -296,6 +352,57 @@ where
         }
     }
 
+    /// Returns the number of bases overlapped by the other interval if
+    /// those intervals are on the same strand
+    ///
+    /// Considers all three cases:
+    /// 1. Both intervals are on the same strand
+    /// 2. Both intervals are on the same chromosome
+    /// 3. Both intervals overlap
+    ///
+    /// Returns `None` if the intervals do not overlap or are not on the same strand
+    /// or chromosome.
+    ///
+    /// ```text
+    /// (Self)    |-------->
+    /// (Other)       |-------->
+    /// (n)           |---->
+    ///
+    /// or
+    /// (Self)    <--------|
+    /// (Other)       <--------|
+    /// (n)           <----|
+    ///
+    /// or
+    /// (Self)    <--------|
+    /// (Other)       |-------->
+    ///               None
+    ///
+    /// or
+    /// (Self)    |-------->
+    /// (Other)       <--------|
+    ///               None
+    /// ```
+    ///
+    /// # Example
+    /// ```
+    /// use bedrs::{StrandedGenomicInterval, Strand, Coordinates, Overlap};
+    ///
+    /// let a = StrandedGenomicInterval::new(1, 100, 200, Strand::Forward);
+    /// let b = StrandedGenomicInterval::new(1, 150, 250, Strand::Forward);
+    /// let c = StrandedGenomicInterval::new(1, 150, 250, Strand::Reverse);
+    ///
+    /// assert_eq!(a.stranded_overlap_size(&b), Some(50));
+    /// assert_eq!(a.stranded_overlap_size(&c), None);
+    /// ```
+    fn stranded_overlap_size<I: Coordinates<C, T>>(&self, other: &I) -> Option<T> {
+        if self.bounded_strand(other) {
+            self.overlap_size(other)
+        } else {
+            None
+        }
+    }
+
     /// Returns true if the current interval contains the other -
     /// considers both the interval overlap and the chromosome.
     ///
@@ -320,6 +427,30 @@ where
         self.bounded_chr(other) && self.interval_contains(other)
     }
 
+    /// Returns true if the current interval contains the other and
+    /// both intervals are on the same strand -
+    ///
+    /// ```text
+    /// (Self)    |-------->
+    /// (Other)     |---->
+    /// ```
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use bedrs::{StrandedGenomicInterval, Strand, Coordinates, Overlap};
+    ///
+    /// let interval1 = StrandedGenomicInterval::new(1, 100, 200, Strand::Forward);
+    /// let interval2 = StrandedGenomicInterval::new(1, 150, 160, Strand::Forward);
+    /// let interval3 = StrandedGenomicInterval::new(1, 150, 160, Strand::Reverse);
+    ///
+    /// assert!(interval1.stranded_contains(&interval2));
+    /// assert!(!interval1.stranded_contains(&interval3));
+    /// ```
+    fn stranded_contains<I: Coordinates<C, T>>(&self, other: &I) -> bool {
+        self.bounded_strand(other) && self.interval_contains(other)
+    }
+
     /// Returns true if the current interval is contained by the other -
     /// considers both the interval overlap and the chromosome.
     ///
@@ -342,6 +473,34 @@ where
     /// ```
     fn contained_by<I: Coordinates<C, T>>(&self, other: &I) -> bool {
         other.contains(self)
+    }
+
+    /// Returns true if the current interval is contained by the other and
+    /// both intervals are on the same strand -
+    ///
+    /// ```text
+    /// (Self)      |---->
+    /// (Other)   |-------->
+    ///
+    /// or
+    /// (Self)      <----|
+    /// (Other)   <--------|
+    /// ```
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use bedrs::{StrandedGenomicInterval, Strand, Coordinates, Overlap};
+    ///
+    /// let interval1 = StrandedGenomicInterval::new(1, 150, 160, Strand::Forward);
+    /// let interval2 = StrandedGenomicInterval::new(1, 100, 200, Strand::Forward);
+    /// let interval3 = StrandedGenomicInterval::new(1, 100, 200, Strand::Reverse);
+    ///
+    /// assert!(interval1.stranded_contained_by(&interval2));
+    /// assert!(!interval1.stranded_contained_by(&interval3));
+    /// ```
+    fn stranded_contained_by<I: Coordinates<C, T>>(&self, other: &I) -> bool {
+        other.stranded_contains(self)
     }
 
     /// Returns true if the current interval borders the other -
@@ -372,6 +531,34 @@ where
     fn borders<I: Coordinates<C, T>>(&self, other: &I) -> bool {
         self.bounded_chr(other) && self.interval_borders(other)
     }
+
+    /// Returns true if the current interval borders the other and
+    /// both intervals are on the same strand -
+    ///
+    /// ```text
+    /// (Self)    |-------->
+    /// (Other)            |-------->
+    ///
+    /// or
+    /// (Self)             <--------|
+    /// (Other)   <--------|
+    /// ```
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use bedrs::{StrandedGenomicInterval, Strand, Coordinates, Overlap};
+    ///
+    /// let interval1 = StrandedGenomicInterval::new(1, 100, 200, Strand::Forward);
+    /// let interval2 = StrandedGenomicInterval::new(1, 200, 300, Strand::Forward);
+    /// let interval3 = StrandedGenomicInterval::new(1, 200, 300, Strand::Reverse);
+    ///
+    /// assert!(interval1.stranded_borders(&interval2));
+    /// assert!(!interval1.stranded_borders(&interval3));
+    /// ```
+    fn stranded_borders<I: Coordinates<C, T>>(&self, other: &I) -> bool {
+        self.bounded_strand(other) && self.borders(other)
+    }
 }
 
 #[cfg(test)]
@@ -379,7 +566,7 @@ mod testing {
     use super::Overlap;
     use crate::{
         types::{record::GenomicInterval, Interval},
-        Coordinates,
+        Coordinates, Strand, StrandedGenomicInterval,
     };
 
     #[test]
@@ -644,5 +831,82 @@ mod testing {
         let a = Interval::new(17, 23);
         let b = Interval::new(15, 25);
         assert_eq!(a.overlap_size(&b), Some(a.len()));
+    }
+
+    #[test]
+    fn overlap_stranded() {
+        let a = StrandedGenomicInterval::new(1, 10, 20, Strand::Forward);
+        let b = StrandedGenomicInterval::new(1, 15, 25, Strand::Forward);
+        let c = StrandedGenomicInterval::new(1, 15, 25, Strand::Reverse);
+        assert!(a.stranded_overlaps(&b));
+        assert!(b.stranded_overlaps(&a));
+        assert!(!a.stranded_overlaps(&c));
+        assert!(!c.stranded_overlaps(&a));
+    }
+
+    #[test]
+    fn overlap_stranded_borders() {
+        let a = StrandedGenomicInterval::new(1, 10, 20, Strand::Forward);
+        let b = StrandedGenomicInterval::new(1, 20, 30, Strand::Forward);
+        let c = StrandedGenomicInterval::new(1, 20, 30, Strand::Reverse);
+        assert!(a.stranded_borders(&b));
+        assert!(b.stranded_borders(&a));
+        assert!(!a.stranded_borders(&c));
+        assert!(!c.stranded_borders(&a));
+    }
+
+    #[test]
+    fn overlap_stranded_contains() {
+        let a = StrandedGenomicInterval::new(1, 10, 20, Strand::Forward);
+        let b = StrandedGenomicInterval::new(1, 15, 17, Strand::Forward);
+        let c = StrandedGenomicInterval::new(1, 15, 17, Strand::Reverse);
+        assert!(a.stranded_contains(&b));
+        assert!(!b.stranded_contains(&a));
+        assert!(!a.stranded_contains(&c));
+        assert!(!c.stranded_contains(&a));
+    }
+
+    #[test]
+    fn overlap_stranded_contained_by() {
+        let a = StrandedGenomicInterval::new(1, 15, 17, Strand::Forward);
+        let b = StrandedGenomicInterval::new(1, 10, 20, Strand::Forward);
+        let c = StrandedGenomicInterval::new(1, 10, 20, Strand::Reverse);
+        assert!(a.stranded_contained_by(&b));
+        assert!(!b.stranded_contained_by(&a));
+        assert!(!a.stranded_contained_by(&c));
+        assert!(!c.stranded_contained_by(&a));
+    }
+
+    #[test]
+    fn overlap_stranded_overlap_size() {
+        let a = StrandedGenomicInterval::new(1, 10, 20, Strand::Forward);
+        let b = StrandedGenomicInterval::new(1, 15, 25, Strand::Forward);
+        let c = StrandedGenomicInterval::new(1, 15, 25, Strand::Reverse);
+        assert_eq!(a.stranded_overlap_size(&b), Some(5));
+        assert_eq!(b.stranded_overlap_size(&a), Some(5));
+        assert_eq!(a.stranded_overlap_size(&c), None);
+        assert_eq!(c.stranded_overlap_size(&a), None);
+    }
+
+    #[test]
+    fn stranded_overlaps_by_exactly() {
+        let a = StrandedGenomicInterval::new(1, 10, 20, Strand::Forward);
+        let b = StrandedGenomicInterval::new(1, 15, 25, Strand::Forward);
+        let c = StrandedGenomicInterval::new(1, 15, 25, Strand::Reverse);
+        assert!(a.stranded_overlaps_by_exactly(&b, 5));
+        assert!(b.stranded_overlaps_by_exactly(&a, 5));
+        assert!(!a.stranded_overlaps_by_exactly(&c, 5));
+        assert!(!c.stranded_overlaps_by_exactly(&a, 5));
+    }
+
+    #[test]
+    fn stranded_overlaps_by() {
+        let a = StrandedGenomicInterval::new(1, 10, 20, Strand::Forward);
+        let b = StrandedGenomicInterval::new(1, 15, 25, Strand::Forward);
+        let c = StrandedGenomicInterval::new(1, 15, 25, Strand::Reverse);
+        assert!(a.stranded_overlaps_by(&b, 5));
+        assert!(b.stranded_overlaps_by(&a, 5));
+        assert!(!a.stranded_overlaps_by(&c, 5));
+        assert!(!c.stranded_overlaps_by(&a, 5));
     }
 }

--- a/src/types/container/stranded_genomic_interval_set.rs
+++ b/src/types/container/stranded_genomic_interval_set.rs
@@ -102,7 +102,7 @@ where
     /// assert_eq!(*span.chr(), 1);
     /// assert_eq!(span.start(), 10);
     /// assert_eq!(span.end(), 500);
-    /// assert_eq!(span.strand(), Strand::Unknown); // Strand is arbitrary in span
+    /// assert_eq!(span.strand().unwrap(), Strand::Unknown); // Strand is arbitrary in span
     /// ```
     fn span(&self) -> Result<StrandedGenomicInterval<T>> {
         if self.is_empty() {
@@ -297,7 +297,7 @@ mod testing {
         let mut set = StrandedGenomicIntervalSet::new(records);
 
         set.records().iter().for_each(|r| {
-            assert_eq!(r.strand(), Strand::Forward);
+            assert_eq!(r.strand().unwrap(), Strand::Forward);
         });
 
         set.records_mut().iter_mut().for_each(|r| {
@@ -305,7 +305,7 @@ mod testing {
         });
 
         set.records().iter().for_each(|r| {
-            assert_eq!(r.strand(), Strand::Reverse);
+            assert_eq!(r.strand().unwrap(), Strand::Reverse);
         });
     }
 

--- a/src/types/container/stranded_genomic_interval_set.rs
+++ b/src/types/container/stranded_genomic_interval_set.rs
@@ -349,6 +349,69 @@ mod testing {
     }
 
     #[test]
+    fn test_sort() {
+        let records = vec![
+            StrandedGenomicInterval::new(1, 1000, 2000, Strand::Reverse),
+            StrandedGenomicInterval::new(1, 1000, 2000, Strand::Forward),
+            StrandedGenomicInterval::new(1, 1000, 2000, Strand::Unknown),
+            StrandedGenomicInterval::new(1, 10, 100, Strand::Reverse),
+            StrandedGenomicInterval::new(1, 10, 100, Strand::Forward),
+            StrandedGenomicInterval::new(1, 10, 100, Strand::Unknown),
+            StrandedGenomicInterval::new(2, 1000, 2000, Strand::Reverse),
+            StrandedGenomicInterval::new(2, 1000, 2000, Strand::Forward),
+            StrandedGenomicInterval::new(2, 1000, 2000, Strand::Unknown),
+            StrandedGenomicInterval::new(2, 10, 100, Strand::Reverse),
+            StrandedGenomicInterval::new(2, 10, 100, Strand::Forward),
+            StrandedGenomicInterval::new(2, 10, 100, Strand::Unknown),
+        ];
+        let set = StrandedGenomicIntervalSet::from_unsorted(records);
+        assert!(set.is_sorted());
+        let vec = set.records();
+        assert!(vec[0].eq(&StrandedGenomicInterval::new(1, 10, 100, Strand::Forward)));
+        assert!(vec[1].eq(&StrandedGenomicInterval::new(1, 10, 100, Strand::Reverse)));
+        assert!(vec[2].eq(&StrandedGenomicInterval::new(1, 10, 100, Strand::Unknown)));
+        assert!(vec[3].eq(&StrandedGenomicInterval::new(
+            1,
+            1000,
+            2000,
+            Strand::Forward
+        )));
+        assert!(vec[4].eq(&StrandedGenomicInterval::new(
+            1,
+            1000,
+            2000,
+            Strand::Reverse
+        )));
+        assert!(vec[5].eq(&StrandedGenomicInterval::new(
+            1,
+            1000,
+            2000,
+            Strand::Unknown
+        )));
+        assert!(vec[6].eq(&StrandedGenomicInterval::new(2, 10, 100, Strand::Forward)));
+        assert!(vec[7].eq(&StrandedGenomicInterval::new(2, 10, 100, Strand::Reverse)));
+        assert!(vec[8].eq(&StrandedGenomicInterval::new(2, 10, 100, Strand::Unknown)));
+        assert!(vec[9].eq(&StrandedGenomicInterval::new(
+            2,
+            1000,
+            2000,
+            Strand::Forward
+        )));
+        assert!(vec[10].eq(&StrandedGenomicInterval::new(
+            2,
+            1000,
+            2000,
+            Strand::Reverse
+        )));
+        assert!(vec[11].eq(&StrandedGenomicInterval::new(
+            2,
+            1000,
+            2000,
+            Strand::Unknown
+        )));
+    }
+
+    #[test]
     #[cfg(feature = "serde")]
     fn test_serialization() {
         let n_intervals = 10;

--- a/src/types/container/stranded_genomic_interval_set.rs
+++ b/src/types/container/stranded_genomic_interval_set.rs
@@ -119,7 +119,7 @@ where
                     *first.chr(),
                     first.start(),
                     last.end(),
-                    Strand::Unknown,
+                    Strand::default(),
                 );
                 Ok(iv)
             }

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -1,4 +1,4 @@
-use rand::{prelude::Distribution, distributions::Standard};
+use rand::{distributions::Standard, prelude::Distribution};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::{

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::{
+    cmp::Ordering,
     fmt::{Display, Formatter},
     str::FromStr,
 };
@@ -156,6 +157,32 @@ impl Display for Strand {
         }
     }
 }
+impl Ord for Strand {
+    /// Sort order for Strand
+    ///
+    /// - Forward < Reverse < Unknown
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (Strand::Forward, Strand::Forward) => Ordering::Equal,
+            (Strand::Forward, Strand::Reverse) => Ordering::Less,
+            (Strand::Forward, Strand::Unknown) => Ordering::Less,
+            (Strand::Reverse, Strand::Forward) => Ordering::Greater,
+            (Strand::Reverse, Strand::Reverse) => Ordering::Equal,
+            (Strand::Reverse, Strand::Unknown) => Ordering::Less,
+            (Strand::Unknown, Strand::Forward) => Ordering::Greater,
+            (Strand::Unknown, Strand::Reverse) => Ordering::Greater,
+            (Strand::Unknown, Strand::Unknown) => Ordering::Equal,
+        }
+    }
+}
+impl PartialOrd for Strand {
+    /// Sort order for Strand
+    ///
+    /// - Forward < Reverse < Unknown
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
 
 #[cfg(test)]
 mod testing {
@@ -244,5 +271,20 @@ mod testing {
         let strand = Strand::Forward;
         let strand_copy = strand;
         assert_eq!(strand, strand_copy);
+    }
+
+    #[test]
+    fn test_strand_ordering() {
+        assert!(Strand::Forward < Strand::Reverse);
+        assert!(Strand::Forward < Strand::Unknown);
+        assert!(Strand::Forward == Strand::Forward);
+
+        assert!(Strand::Reverse > Strand::Forward);
+        assert!(Strand::Reverse < Strand::Unknown);
+        assert!(Strand::Reverse == Strand::Reverse);
+
+        assert!(Strand::Unknown > Strand::Forward);
+        assert!(Strand::Unknown > Strand::Reverse);
+        assert!(Strand::Unknown == Strand::Unknown);
     }
 }

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -1,0 +1,75 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+use std::{
+    fmt::{Display, Formatter},
+    str::FromStr,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum Strand {
+    Forward,
+    Reverse,
+    #[default]
+    Unknown,
+}
+impl FromStr for Strand {
+    type Err = &'static str;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "+" => Ok(Strand::Forward),
+            "-" => Ok(Strand::Reverse),
+            "." => Ok(Strand::Unknown),
+            _ => Err("Strand must be either + or -"),
+        }
+    }
+}
+impl TryFrom<char> for Strand {
+    type Error = &'static str;
+    fn try_from(c: char) -> Result<Self, Self::Error> {
+        match c {
+            '+' => Ok(Strand::Forward),
+            '-' => Ok(Strand::Reverse),
+            '.' => Ok(Strand::Unknown),
+            _ => Err("Strand must be either + or -"),
+        }
+    }
+}
+impl TryFrom<u8> for Strand {
+    type Error = &'static str;
+    fn try_from(c: u8) -> Result<Self, Self::Error> {
+        match c {
+            b'+' => Ok(Strand::Forward),
+            b'-' => Ok(Strand::Reverse),
+            b'.' => Ok(Strand::Unknown),
+            _ => Err("Strand must be either + or -"),
+        }
+    }
+}
+impl Into<char> for Strand {
+    fn into(self) -> char {
+        match self {
+            Strand::Forward => '+',
+            Strand::Reverse => '-',
+            Strand::Unknown => '.',
+        }
+    }
+}
+impl Into<u8> for Strand {
+    fn into(self) -> u8 {
+        match self {
+            Strand::Forward => b'+',
+            Strand::Reverse => b'-',
+            Strand::Unknown => b'.',
+        }
+    }
+}
+impl Display for Strand {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Strand::Forward => write!(f, "+"),
+            Strand::Reverse => write!(f, "-"),
+            Strand::Unknown => write!(f, "."),
+        }
+    }
+}

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -15,6 +15,23 @@ pub enum Strand {
 }
 impl FromStr for Strand {
     type Err = &'static str;
+
+    /// Convert a string to a Strand
+    ///
+    /// # Arguments
+    /// * `s` - A string slice to convert to a Strand
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use bedrs::Strand;
+    /// use std::str::FromStr;
+    ///
+    /// assert_eq!(Strand::from_str("+").unwrap(), Strand::Forward);
+    /// assert_eq!(Strand::from_str("-").unwrap(), Strand::Reverse);
+    /// assert_eq!(Strand::from_str(".").unwrap(), Strand::Unknown);
+    /// assert!(Strand::from_str("a").is_err());
+    /// ```
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "+" => Ok(Strand::Forward),
@@ -26,6 +43,22 @@ impl FromStr for Strand {
 }
 impl TryFrom<char> for Strand {
     type Error = &'static str;
+
+    /// Convert a char to a Strand
+    ///
+    /// # Arguments
+    /// * `c` - A char to convert to a Strand
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use bedrs::Strand;
+    ///
+    /// assert_eq!(Strand::try_from('+').unwrap(), Strand::Forward);
+    /// assert_eq!(Strand::try_from('-').unwrap(), Strand::Reverse);
+    /// assert_eq!(Strand::try_from('.').unwrap(), Strand::Unknown);
+    /// assert!(Strand::try_from('a').is_err());
+    /// ```
     fn try_from(c: char) -> Result<Self, Self::Error> {
         match c {
             '+' => Ok(Strand::Forward),
@@ -37,6 +70,21 @@ impl TryFrom<char> for Strand {
 }
 impl TryFrom<u8> for Strand {
     type Error = &'static str;
+
+    /// Convert a u8 to a Strand
+    ///
+    /// # Arguments
+    /// * `c` - A u8 to convert to a Strand
+    ///
+    /// # Example
+    /// ```
+    /// use bedrs::Strand;
+    ///
+    /// assert_eq!(Strand::try_from(b'+').unwrap(), Strand::Forward);
+    /// assert_eq!(Strand::try_from(b'-').unwrap(), Strand::Reverse);
+    /// assert_eq!(Strand::try_from(b'.').unwrap(), Strand::Unknown);
+    /// assert!(Strand::try_from(b'a').is_err());
+    /// ```
     fn try_from(c: u8) -> Result<Self, Self::Error> {
         match c {
             b'+' => Ok(Strand::Forward),
@@ -47,6 +95,21 @@ impl TryFrom<u8> for Strand {
     }
 }
 impl Into<char> for Strand {
+    /// Convert a Strand to a char
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use bedrs::Strand;
+    ///
+    /// let char_forward: char = Strand::Forward.into();
+    /// let char_reverse: char = Strand::Reverse.into();
+    /// let char_unknown: char = Strand::Unknown.into();
+    ///
+    /// assert_eq!(char_forward, '+');
+    /// assert_eq!(char_reverse, '-');
+    /// assert_eq!(char_unknown, '.');
+    /// ```
     fn into(self) -> char {
         match self {
             Strand::Forward => '+',
@@ -56,6 +119,21 @@ impl Into<char> for Strand {
     }
 }
 impl Into<u8> for Strand {
+    /// Convert a Strand to a u8
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use bedrs::Strand;
+    ///
+    /// let u8_forward: u8 = Strand::Forward.into();
+    /// let u8_reverse: u8 = Strand::Reverse.into();
+    /// let u8_unknown: u8 = Strand::Unknown.into();
+    ///
+    /// assert_eq!(u8_forward, b'+');
+    /// assert_eq!(u8_reverse, b'-');
+    /// assert_eq!(u8_unknown, b'.');
+    /// ```
     fn into(self) -> u8 {
         match self {
             Strand::Forward => b'+',
@@ -65,11 +143,106 @@ impl Into<u8> for Strand {
     }
 }
 impl Display for Strand {
+    /// Display a strand in a human readable format
+    ///
+    /// - Forward is displayed as `+`
+    /// - Reverse is displayed as `-`
+    /// - Unknown is displayed as `.`
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Strand::Forward => write!(f, "+"),
             Strand::Reverse => write!(f, "-"),
             Strand::Unknown => write!(f, "."),
         }
+    }
+}
+
+#[cfg(test)]
+mod testing {
+
+    use super::*;
+
+    #[test]
+    fn test_strand_from_str() {
+        assert_eq!(Strand::from_str("+").unwrap(), Strand::Forward);
+        assert_eq!(Strand::from_str("-").unwrap(), Strand::Reverse);
+        assert_eq!(Strand::from_str(".").unwrap(), Strand::Unknown);
+        assert!(Strand::from_str("a").is_err());
+    }
+
+    #[test]
+    fn test_strand_try_from_char() {
+        assert_eq!(Strand::try_from('+').unwrap(), Strand::Forward);
+        assert_eq!(Strand::try_from('-').unwrap(), Strand::Reverse);
+        assert_eq!(Strand::try_from('.').unwrap(), Strand::Unknown);
+        assert!(Strand::try_from('a').is_err());
+    }
+
+    #[test]
+    fn test_strand_try_from_u8() {
+        assert_eq!(Strand::try_from(b'+').unwrap(), Strand::Forward);
+        assert_eq!(Strand::try_from(b'-').unwrap(), Strand::Reverse);
+        assert_eq!(Strand::try_from(b'.').unwrap(), Strand::Unknown);
+        assert!(Strand::try_from(b'a').is_err());
+    }
+
+    #[test]
+    fn test_strand_into_char() {
+        let char_forward: char = Strand::Forward.into();
+        let char_reverse: char = Strand::Reverse.into();
+        let char_unknown: char = Strand::Unknown.into();
+        assert_eq!(char_forward, '+');
+        assert_eq!(char_reverse, '-');
+        assert_eq!(char_unknown, '.');
+    }
+
+    #[test]
+    fn test_strand_into_u8() {
+        let u8_forward: u8 = Strand::Forward.into();
+        let u8_reverse: u8 = Strand::Reverse.into();
+        let u8_unknown: u8 = Strand::Unknown.into();
+        assert_eq!(u8_forward, b'+');
+        assert_eq!(u8_reverse, b'-');
+        assert_eq!(u8_unknown, b'.');
+    }
+
+    #[test]
+    fn test_strand_display() {
+        assert_eq!(format!("{}", Strand::Forward), "+");
+        assert_eq!(format!("{}", Strand::Reverse), "-");
+        assert_eq!(format!("{}", Strand::Unknown), ".");
+    }
+
+    #[test]
+    fn test_strand_default() {
+        assert_eq!(Strand::default(), Strand::Unknown);
+    }
+
+    #[test]
+    fn test_strand_eq() {
+        assert_eq!(Strand::Forward, Strand::Forward);
+        assert_eq!(Strand::Reverse, Strand::Reverse);
+        assert_eq!(Strand::Unknown, Strand::Unknown);
+    }
+
+    #[test]
+    fn test_strand_ne() {
+        assert_ne!(Strand::Forward, Strand::Reverse);
+        assert_ne!(Strand::Forward, Strand::Unknown);
+        assert_ne!(Strand::Reverse, Strand::Unknown);
+    }
+
+    #[test]
+    fn test_strand_clone() {
+        assert_eq!(Strand::Forward.clone(), Strand::Forward);
+        assert_eq!(Strand::Reverse.clone(), Strand::Reverse);
+        assert_eq!(Strand::Unknown.clone(), Strand::Unknown);
+    }
+
+    #[test]
+    fn test_strand_copy() {
+        let strand = Strand::Forward;
+        let strand_copy = strand;
+        assert_eq!(strand, strand_copy);
     }
 }

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -1,3 +1,4 @@
+use rand::{prelude::Distribution, distributions::Standard};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::{
@@ -9,10 +10,22 @@ use std::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Strand {
+    #[cfg_attr(feature = "serde", serde(rename = "+"))]
     Forward,
+    #[cfg_attr(feature = "serde", serde(rename = "-"))]
     Reverse,
+    #[cfg_attr(feature = "serde", serde(rename = "."))]
     #[default]
     Unknown,
+}
+impl Distribution<Strand> for Standard {
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> Strand {
+        match rng.gen_range(0..2) {
+            0 => Strand::Forward,
+            1 => Strand::Reverse,
+            _ => Strand::Unknown, // this should never happen
+        }
+    }
 }
 impl FromStr for Strand {
     type Err = &'static str;
@@ -286,5 +299,13 @@ mod testing {
         assert!(Strand::Unknown > Strand::Forward);
         assert!(Strand::Unknown > Strand::Reverse);
         assert!(Strand::Unknown == Strand::Unknown);
+    }
+
+    #[test]
+    fn test_random_draws() {
+        for _ in 0..100 {
+            let strand: Strand = rand::random();
+            assert!(strand == Strand::Forward || strand == Strand::Reverse);
+        }
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,9 +1,11 @@
 pub mod container;
+pub mod enums;
 pub mod iterator;
 pub mod record;
 pub use container::{GenomicIntervalSet, IntervalSet, MergeResults, StrandedGenomicIntervalSet};
+pub use enums::Strand;
 pub use iterator::{
     FindIter, FindIterSorted, IntersectIter, IntervalIterOwned, IntervalIterRef, MergeIter,
     SubtractFromIter, SubtractIter,
 };
-pub use record::{GenomicInterval, Interval, NamedInterval, Strand, StrandedGenomicInterval};
+pub use record::{GenomicInterval, Interval, NamedInterval, StrandedGenomicInterval};

--- a/src/types/record/mod.rs
+++ b/src/types/record/mod.rs
@@ -5,4 +5,4 @@ mod stranded_genomic_interval;
 pub use genomic_interval::GenomicInterval;
 pub use interval::Interval;
 pub use named_interval::NamedInterval;
-pub use stranded_genomic_interval::{Strand, StrandedGenomicInterval};
+pub use stranded_genomic_interval::StrandedGenomicInterval;

--- a/src/types/record/stranded_genomic_interval.rs
+++ b/src/types/record/stranded_genomic_interval.rs
@@ -1,20 +1,23 @@
-use crate::traits::{Coordinates, ValueBounds};
+use crate::{
+    traits::{Coordinates, ValueBounds},
+    Strand,
+};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum Strand {
-    /// The forward strand
-    Forward,
+// #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+// #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+// pub enum Strand {
+//     /// The forward strand
+//     Forward,
 
-    /// The reverse strand
-    Reverse,
+//     /// The reverse strand
+//     Reverse,
 
-    /// Unknown strand
-    #[default]
-    Unknown,
-}
+//     /// Unknown strand
+//     #[default]
+//     Unknown,
+// }
 
 /// A representation of a Genomic Interval.
 ///

--- a/src/types/record/stranded_genomic_interval.rs
+++ b/src/types/record/stranded_genomic_interval.rs
@@ -5,20 +5,6 @@ use crate::{
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-// #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
-// #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-// pub enum Strand {
-//     /// The forward strand
-//     Forward,
-
-//     /// The reverse strand
-//     Reverse,
-
-//     /// Unknown strand
-//     #[default]
-//     Unknown,
-// }
-
 /// A representation of a Genomic Interval.
 ///
 /// Has three coordinates: `chr`, `start`, and `end`.


### PR DESCRIPTION
- Including a public enum strand for Forward, Reverse, and Unknown
- Have `Coordinates` trait return an `Option<Strand>`
- Added stranded overlap and intersection methods
- Added Ordering to `Strand`
- Included `Strand` ordering in Coord Comparison